### PR TITLE
[H-03] removeLiquidity logic is not correct

### DIFF
--- a/mocks/functions/MockEmptyFunction.sol
+++ b/mocks/functions/MockEmptyFunction.sol
@@ -24,6 +24,15 @@ contract MockEmptyFunction is IWellFunction {
         return 1;
     }
 
+    function calcLPTokenUnderlying(
+        uint256 lpTokenAmount,
+        uint256[] memory reserves,
+        uint256 lpTokenSupply,
+        bytes calldata data
+    ) external pure returns (uint[] memory underlyingAmounts) {
+        return underlyingAmounts;
+    }
+
     function name() external override pure returns (string memory) {}
 
     function symbol() external override pure returns (string memory) {}

--- a/mocks/functions/MockFunctionBad.sol
+++ b/mocks/functions/MockFunctionBad.sol
@@ -33,6 +33,15 @@ contract MockFunctionBad is IWellFunction {
         return 1000;
     }
 
+    function calcLPTokenUnderlying(
+        uint256,
+        uint256[] memory,
+        uint256,
+        bytes calldata
+    ) external pure returns (uint[] memory underlyingAmounts) {
+        return underlyingAmounts;
+    }
+
     function name() external override pure returns (string memory) {}
 
     function symbol() external override pure returns (string memory) {}

--- a/src/Well.sol
+++ b/src/Well.sol
@@ -682,7 +682,9 @@ contract Well is ERC20PermitUpgradeable, IWell, ReentrancyGuardUpgradeable, Clon
         uint[] memory reserves,
         uint lpTokenSupply
     ) internal view returns (uint[] memory tokenAmounts) {
-        tokenAmounts = IWellFunction(_wellFunction.target).calcLPTokenUnderlying(lpTokenAmount, reserves, lpTokenSupply, _wellFunction.data);
+        tokenAmounts = IWellFunction(_wellFunction.target).calcLPTokenUnderlying(
+            lpTokenAmount, reserves, lpTokenSupply, _wellFunction.data
+        );
     }
 
     //////////////////// INTERNAL: WELL TOKEN INDEXING ////////////////////

--- a/src/functions/ConstantProduct.sol
+++ b/src/functions/ConstantProduct.sol
@@ -6,10 +6,10 @@ import {ProportionalLPToken} from "src/functions/ProportionalLPToken.sol";
 import {LibMath} from "src/libraries/LibMath.sol";
 
 /**
+ * @title ConstantProduct
  * @author Publius
- * @title Constant Product pricing function for Wells with 2 tokens
- *
- * Constant Product Wells use the formula:
+ * @notice Constant product pricing function for Wells with N tokens.
+ * @dev Constant Product Wells use the formula:
  *  `π(b_i) = (s / n)^n`
  *
  * Where:

--- a/src/functions/ConstantProduct.sol
+++ b/src/functions/ConstantProduct.sol
@@ -2,7 +2,7 @@
 
 pragma solidity ^0.8.17;
 
-import {IWellFunction} from "src/interfaces/IWellFunction.sol";
+import {ProportionalLPToken} from "src/functions/ProportionalLPToken.sol";
 import {LibMath} from "src/libraries/LibMath.sol";
 
 /**
@@ -17,7 +17,7 @@ import {LibMath} from "src/libraries/LibMath.sol";
  *  `b_i` is the reserve at index `i`
  *  `n` is the number of tokens in the Well
  */
-contract ConstantProduct is IWellFunction {
+contract ConstantProduct is ProportionalLPToken {
     using LibMath for uint;
 
     /// @dev `s = π(b_i)^(1/n) * n`

--- a/src/functions/ConstantProduct2.sol
+++ b/src/functions/ConstantProduct2.sol
@@ -21,7 +21,30 @@ contract ConstantProduct2 is ProportionalLPToken2 {
 
     uint constant EXP_PRECISION = 1e12;
 
-    /// @dev `s = (b_0 * b_1)^(1/2)`
+    /**
+     * @dev `s = (b_0 * b_1)^(1/2)`
+     *
+     * When does this function overflow?
+     * ---------------------------------
+     *
+     * Let N be the length of the reserves array, and P be the precision multiplier
+     * defined in `EXP_PRECISION`.
+     *
+     * Assuming all tokens in reserves are at their maximum value simultaneously,
+     * this function will overflow when:
+     *
+     *  (10^X)^N * P >= MAX_UINT256 (~10^77)
+     *  10^(X*N) >= 10^77/P
+     *  (X*N)*ln(10) >= 77*ln(10) - ln(P)
+     *
+     *  ∴ X >= (1/N) * (77 - ln(P)/ln(10))
+     *
+     * ConstantProduct2 sets the constraints `N = 2` and `EXP_PRECISION = 1e12`,
+     * resulting in an upper bound of X = 32.5.
+     *
+     * In other words, {calcLpTokenSupply} overflows if all reserves are simultaneously
+     * >= 10^32.5, or about 100 trillion if tokens are measured to 18 decimal precision.
+     */
     function calcLpTokenSupply(
         uint[] calldata reserves,
         bytes calldata

--- a/src/functions/ConstantProduct2.sol
+++ b/src/functions/ConstantProduct2.sol
@@ -2,7 +2,7 @@
 
 pragma solidity ^0.8.17;
 
-import {IWellFunction} from "src/interfaces/IWellFunction.sol";
+import {ProportionalLPToken2} from "src/functions/ProportionalLPToken2.sol";
 import {LibMath} from "src/libraries/LibMath.sol";
 
 /**
@@ -16,7 +16,7 @@ import {LibMath} from "src/libraries/LibMath.sol";
  *  `s` is the supply of LP tokens
  *  `b_i` is the reserve at index `i`
  */
-contract ConstantProduct2 is IWellFunction {
+contract ConstantProduct2 is ProportionalLPToken2 {
     using LibMath for uint;
 
     uint constant EXP_PRECISION = 1e12;

--- a/src/functions/ConstantProduct2.sol
+++ b/src/functions/ConstantProduct2.sol
@@ -6,10 +6,10 @@ import {ProportionalLPToken2} from "src/functions/ProportionalLPToken2.sol";
 import {LibMath} from "src/libraries/LibMath.sol";
 
 /**
+ * @title ConstantProduct2
  * @author Publius
- * @title Gas efficient Constant Product pricing function for Wells with 2 tokens.
- *
- * Constant Product Wells with 2 tokens use the formula:
+ * @notice Gas efficient Constant Product pricing function for Wells with 2 tokens.
+ * @dev Constant Product Wells with 2 tokens use the formula:
  *  `b_0 * b_1 = s^2`
  *
  * Where:
@@ -42,10 +42,10 @@ contract ConstantProduct2 is ProportionalLPToken2 {
     }
 
     function name() external pure override returns (string memory) {
-        return "Constant Product";
+        return "Constant Product 2";
     }
 
     function symbol() external pure override returns (string memory) {
-        return "CP";
+        return "CP2";
     }
 }

--- a/src/functions/ProportionalLPToken.sol
+++ b/src/functions/ProportionalLPToken.sol
@@ -5,24 +5,22 @@ pragma solidity ^0.8.17;
 import {IWellFunction} from "src/interfaces/IWellFunction.sol";
 
 /**
- * @title Proportional LP Token defines the `calcLPTokenUnderlying` function for 
- * Wells with a proportional relationship between the LP Token and all of the underlying tokens.
- *
- * @dev When removing s LP tokens with a Well with S total LP tokens, they recieve:
- * s * B_i / S of each underlying token.
+ * @title ProportionalLPToken
+ * @notice Defines a proportional relationship between the supply of LP tokens
+ * and the amount of each underlying token for an N-token Well.
+ * @dev When removing `s` LP tokens with a Well with `S` LP token supply, the user
+ * recieves `s * b_i / S` of each underlying token.
  */
 abstract contract ProportionalLPToken is IWellFunction {
-
     function calcLPTokenUnderlying(
         uint lpTokenAmount,
         uint[] calldata reserves,
         uint lpTokenSupply,
         bytes calldata
-    ) external pure override returns (uint[] memory underlyingAmounts) {
+    ) external pure returns (uint[] memory underlyingAmounts) {
         underlyingAmounts = new uint[](reserves.length);
         for (uint i; i < reserves.length; ++i) {
             underlyingAmounts[i] = lpTokenAmount * reserves[i] / lpTokenSupply;
         }
     }
-
 }

--- a/src/functions/ProportionalLPToken.sol
+++ b/src/functions/ProportionalLPToken.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.17;
+
+import {IWellFunction} from "src/interfaces/IWellFunction.sol";
+
+/**
+ * @title Proportional LP Token defines the `calcLPTokenUnderlying` function for 
+ * Wells with a proportional relationship between the LP Token and all of the underlying tokens.
+ *
+ * @dev When removing s LP tokens with a Well with S total LP tokens, they recieve:
+ * s * B_i / S of each underlying token.
+ */
+abstract contract ProportionalLPToken is IWellFunction {
+
+    function calcLPTokenUnderlying(
+        uint lpTokenAmount,
+        uint[] calldata reserves,
+        uint lpTokenSupply,
+        bytes calldata
+    ) external pure override returns (uint[] memory underlyingAmounts) {
+        underlyingAmounts = new uint[](reserves.length);
+        for (uint i; i < reserves.length; ++i) {
+            underlyingAmounts[i] = lpTokenAmount * reserves[i] / lpTokenSupply;
+        }
+    }
+
+}

--- a/src/functions/ProportionalLPToken2.sol
+++ b/src/functions/ProportionalLPToken2.sol
@@ -5,23 +5,21 @@ pragma solidity ^0.8.17;
 import {IWellFunction} from "src/interfaces/IWellFunction.sol";
 
 /**
- * @title Proportional LP Token 2 defines the `calcLPTokenUnderlying` function for 
- * Wells with 2 tokens and a proportional relationship between the LP Token and all of the underlying tokens.
- *
- * @dev When removing s LP tokens with a Well with S total LP tokens, they recieve:
- * s * B_i / S of each underlying token.
+ * @title ProportionalLPToken2
+ * @notice Defines a proportional relationship between the supply of LP tokens
+ * and the amount of each underlying token for a two-token Well.
+ * @dev When removing `s` LP tokens with a Well with `S` LP token supply, the user
+ * recieves `s * b_i / S` of each underlying token.
  */
 abstract contract ProportionalLPToken2 is IWellFunction {
-
     function calcLPTokenUnderlying(
         uint lpTokenAmount,
         uint[] calldata reserves,
         uint lpTokenSupply,
         bytes calldata
-    ) external pure override returns (uint[] memory underlyingAmounts) {
+    ) external pure returns (uint[] memory underlyingAmounts) {
         underlyingAmounts = new uint[](2);
         underlyingAmounts[0] = lpTokenAmount * reserves[0] / lpTokenSupply;
         underlyingAmounts[1] = lpTokenAmount * reserves[1] / lpTokenSupply;
     }
-
 }

--- a/src/functions/ProportionalLPToken2.sol
+++ b/src/functions/ProportionalLPToken2.sol
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.17;
+
+import {IWellFunction} from "src/interfaces/IWellFunction.sol";
+
+/**
+ * @title Proportional LP Token 2 defines the `calcLPTokenUnderlying` function for 
+ * Wells with 2 tokens and a proportional relationship between the LP Token and all of the underlying tokens.
+ *
+ * @dev When removing s LP tokens with a Well with S total LP tokens, they recieve:
+ * s * B_i / S of each underlying token.
+ */
+abstract contract ProportionalLPToken2 is IWellFunction {
+
+    function calcLPTokenUnderlying(
+        uint lpTokenAmount,
+        uint[] calldata reserves,
+        uint lpTokenSupply,
+        bytes calldata
+    ) external pure override returns (uint[] memory underlyingAmounts) {
+        underlyingAmounts = new uint[](2);
+        underlyingAmounts[0] = lpTokenAmount * reserves[0] / lpTokenSupply;
+        underlyingAmounts[1] = lpTokenAmount * reserves[1] / lpTokenSupply;
+    }
+
+}

--- a/src/interfaces/IWellFunction.sol
+++ b/src/interfaces/IWellFunction.sol
@@ -38,6 +38,21 @@ interface IWellFunction {
     ) external view returns (uint lpTokenSupply);
 
     /**
+     * @notice Calculates the amount of tokens underlying a given amount of LP tokens.
+     * @param lpTokenAmount The amount of LP tokens
+     * @param reserves A list of token reserves
+     * @param lpTokenSupply The supply of LP tokens
+     * @param data Well function data provided on every call
+     * @return underlyingAmounts The amount of tokens underlying the LP tokens
+     */
+    function calcLPTokenUnderlying(
+        uint lpTokenAmount,
+        uint[] memory reserves,
+        uint lpTokenSupply,
+        bytes calldata data
+    ) external view returns (uint[] memory underlyingAmounts);
+
+    /**
      * @notice Returns the name of the Well function.
      * @dev Used in Well building.
      */

--- a/src/interfaces/IWellFunction.sol
+++ b/src/interfaces/IWellFunction.sol
@@ -16,7 +16,7 @@ interface IWellFunction {
      * @param reserves A list of token reserves. The jth reserve will be ignored, but a placeholder must be provided.
      * @param j The index of the reserve to solve for
      * @param lpTokenSupply The supply of LP tokens
-     * @param data Well function data provided on every call
+     * @param data Extra Well function data provided on every call
      * @return reserve The resulting reserve at the jth index
      */
     function calcReserve(
@@ -29,7 +29,7 @@ interface IWellFunction {
     /**
      * @notice Gets the LP token supply given a list of reserves.
      * @param reserves A list of token reserves
-     * @param data Well function data provided on every call
+     * @param data Extra Well function data provided on every call
      * @return lpTokenSupply The resulting supply of LP tokens
      */
     function calcLpTokenSupply(
@@ -38,12 +38,12 @@ interface IWellFunction {
     ) external view returns (uint lpTokenSupply);
 
     /**
-     * @notice Calculates the amount of tokens underlying a given amount of LP tokens.
-     * @param lpTokenAmount The amount of LP tokens
+     * @notice Calculates the amount of each reserve token underlying a given amount of LP tokens.
+     * @param lpTokenAmount An amount of LP tokens
      * @param reserves A list of token reserves
-     * @param lpTokenSupply The supply of LP tokens
-     * @param data Well function data provided on every call
-     * @return underlyingAmounts The amount of tokens underlying the LP tokens
+     * @param lpTokenSupply The current supply of LP tokens
+     * @param data Extra Well function data provided on every call
+     * @return underlyingAmounts The amount of each reserve token that underlies the LP tokens
      */
     function calcLPTokenUnderlying(
         uint lpTokenAmount,
@@ -54,13 +54,11 @@ interface IWellFunction {
 
     /**
      * @notice Returns the name of the Well function.
-     * @dev Used in Well building.
      */
     function name() external view returns (string memory);
 
     /**
      * @notice Returns the symbol of the Well function.
-     * @dev Used in Well building.
      */
     function symbol() external view returns (string memory);
 }

--- a/src/interfaces/IWellFunction.sol
+++ b/src/interfaces/IWellFunction.sol
@@ -44,6 +44,9 @@ interface IWellFunction {
      * @param lpTokenSupply The current supply of LP tokens
      * @param data Extra Well function data provided on every call
      * @return underlyingAmounts The amount of each reserve token that underlies the LP tokens
+     * @dev The constraint totalSupply() <= calcLPTokenSupply(...) must be held in the case where
+     * `lpTokenAmount` LP tokens are burned in exchanged for `underlyingAmounts`. If the constraint
+     * does not hold, then the Well Function is invalid.
      */
     function calcLPTokenUnderlying(
         uint lpTokenAmount,

--- a/src/interfaces/pumps/ICumulativePump.sol
+++ b/src/interfaces/pumps/ICumulativePump.sol
@@ -4,7 +4,9 @@ pragma solidity =0.8.17;
 pragma experimental ABIEncoderV2;
 
 /**
- * @title Cumulative Pumps provide an Oracle for time weighted average reserves through the use of a cumulative reserve.
+ * @title ICumulativePump
+ * @notice Provides an interface for Pumps which calculate time-weighted average
+ * reserves through the use of a cumulative reserve.
  */
 interface ICumulativePump {
     /**

--- a/test/Well.AddLiquidity.t.sol
+++ b/test/Well.AddLiquidity.t.sol
@@ -3,7 +3,7 @@
 pragma solidity ^0.8.17;
 
 import {TestHelper, IERC20, Call, Balances} from "test/TestHelper.sol";
-import {ConstantProduct2, IWellFunction} from "src/functions/ConstantProduct2.sol";
+import {ConstantProduct2} from "src/functions/ConstantProduct2.sol";
 import {Snapshot, AddLiquidityAction, RemoveLiquidityAction, LiquidityHelper} from "test/LiquidityHelper.sol";
 
 contract WellAddLiquidityTest is LiquidityHelper {

--- a/test/Well.AddLiquidityFeeOnTransfer.Fee.t.sol
+++ b/test/Well.AddLiquidityFeeOnTransfer.Fee.t.sol
@@ -3,7 +3,7 @@
 pragma solidity ^0.8.17;
 
 import {MockTokenFeeOnTransfer, TestHelper, IERC20, Call, Balances} from "test/TestHelper.sol";
-import {ConstantProduct2, IWellFunction} from "src/functions/ConstantProduct2.sol";
+import {ConstantProduct2} from "src/functions/ConstantProduct2.sol";
 import {Snapshot, AddLiquidityAction, RemoveLiquidityAction, LiquidityHelper} from "test/LiquidityHelper.sol";
 
 contract WellAddLiquidityFeeOnTransferWithFeeTest is LiquidityHelper {

--- a/test/Well.AddLiquidityFeeOnTransfer.NoFee.t.sol
+++ b/test/Well.AddLiquidityFeeOnTransfer.NoFee.t.sol
@@ -3,7 +3,7 @@
 pragma solidity ^0.8.17;
 
 import {TestHelper, IERC20, Call, Balances} from "test/TestHelper.sol";
-import {ConstantProduct2, IWellFunction} from "src/functions/ConstantProduct2.sol";
+import {ConstantProduct2} from "src/functions/ConstantProduct2.sol";
 import {Snapshot, AddLiquidityAction, RemoveLiquidityAction, LiquidityHelper} from "test/LiquidityHelper.sol";
 
 contract WellAddLiquidityFeeOnTransferNoFeeTest is LiquidityHelper {

--- a/test/Well.Bore.t.sol
+++ b/test/Well.Bore.t.sol
@@ -59,11 +59,11 @@ contract WellBoreTest is TestHelper {
     //////////// ERC20 LP Token ////////////
 
     function test_name() public {
-        assertEq(well.name(), "TOKEN0:TOKEN1:TOKEN2:TOKEN3 Constant Product Well");
+        assertEq(well.name(), "TOKEN0:TOKEN1:TOKEN2:TOKEN3 Constant Product 2 Well");
     }
 
     function test_symbol() public {
-        assertEq(well.symbol(), "TOKEN0TOKEN1TOKEN2TOKEN3CPw");
+        assertEq(well.symbol(), "TOKEN0TOKEN1TOKEN2TOKEN3CP2w");
     }
 
     function test_decimals() public {

--- a/test/Well.FeeOnTransfer.t.sol
+++ b/test/Well.FeeOnTransfer.t.sol
@@ -3,7 +3,7 @@
 pragma solidity ^0.8.17;
 
 import {TestHelper, IERC20, Call, Balances, MockTokenFeeOnTransfer} from "test/TestHelper.sol";
-import {ConstantProduct2, IWellFunction} from "src/functions/ConstantProduct2.sol";
+import {ConstantProduct2} from "src/functions/ConstantProduct2.sol";
 import {IWell} from "src/interfaces/IWell.sol";
 
 /**

--- a/test/Well.RemoveLiquidity.t.sol
+++ b/test/Well.RemoveLiquidity.t.sol
@@ -96,6 +96,11 @@ contract WellRemoveLiquidityTest is LiquidityHelper {
         (before, action) = beforeRemoveLiquidity(action);
         well.removeLiquidity(lpAmountIn, amounts, user, type(uint).max);
         afterRemoveLiquidity(before, action);
+
+        assertLe(
+            well.totalSupply(),
+            ConstantProduct2(wellFunction.target).calcLpTokenSupply(well.getReserves(), wellFunction.data)
+        );
     }
 
     /// @dev Fuzz test: UNEQUAL token reserves, BALANCED removal

--- a/test/functions/ConstantProduct2.t.sol
+++ b/test/functions/ConstantProduct2.t.sol
@@ -22,6 +22,9 @@ contract ConstantProduct2Test is WellFunctionHelper {
     uint STATE_C_B1 = 31_250_000_000_000_000_000; // 3.125e19
     uint STATE_C_LP = 25 * 1e24;
 
+    /// @dev See {calcLpTokenSupply}.
+    uint MAX_RESERVE = 1e32;
+
     //////////// SETUP ////////////
 
     function setUp() public {
@@ -37,12 +40,12 @@ contract ConstantProduct2Test is WellFunctionHelper {
     //////////// LP TOKEN SUPPLY ////////////
 
     /// @dev reverts when trying to calculate lp token supply with < 2 reserves
-    function test_getLpTokenSupply_minBalancesLength() public {
-        check_getLpTokenSupply_minBalancesLength(2);
+    function test_calcLpTokenSupply_minBalancesLength() public {
+        check_calcLpTokenSupply_minBalancesLength(2);
     }
 
     /// @dev calcLpTokenSupply: same decimals, manual calc for 2 equal reserves
-    function test_getLpTokenSupply_sameDecimals() public {
+    function test_calcLpTokenSupply_sameDecimals() public {
         uint[] memory reserves = new uint[](2);
         reserves[0] = STATE_A_B0;
         reserves[1] = STATE_A_B1;
@@ -53,7 +56,7 @@ contract ConstantProduct2Test is WellFunctionHelper {
     }
 
     /// @dev calcLpTokenSupply: diff decimals
-    function test_getLpTokenSupply_diffDecimals() public {
+    function test_calcLpTokenSupply_diffDecimals() public {
         uint[] memory reserves = new uint[](2);
         reserves[0] = STATE_B_B0; // ex. 1 WETH
         reserves[1] = STATE_B_B1; // ex. 1250 BEAN
@@ -63,11 +66,11 @@ contract ConstantProduct2Test is WellFunctionHelper {
         );
     }
 
-    //////////// BALANCES ////////////
+    //////////// RESERVES ////////////
 
-    /// @dev getBalance: same decimals, both positions
+    /// @dev calcReserve: same decimals, both positions
     /// Matches example in {testLpTokenSupplySameDecimals}.
-    function test_getBalance_sameDecimals() public {
+    function test_calcReserve_sameDecimals() public {
         uint[] memory reserves = new uint[](2);
 
         /// STATE A
@@ -94,9 +97,9 @@ contract ConstantProduct2Test is WellFunctionHelper {
         );
     }
 
-    /// @dev getBalance: diff decimals, both positions
+    /// @dev calcReserve: diff decimals, both positions
     /// Matches example in {testLpTokenSupplyDiffDecimals}.
-    function test_getBalance_diffDecimals() public {
+    function test_calcReserve_diffDecimals() public {
         uint[] memory reserves = new uint[](2);
 
         /// STATE B
@@ -117,16 +120,33 @@ contract ConstantProduct2Test is WellFunctionHelper {
         );
     }
 
-    function test_fuzz_constantProduct(uint x, uint y) public {
+    //////////// LP TOKEN SUPPLY ////////////
+
+    /// @dev invariant: reserves -> lpTokenSupply -> reserves should match
+    function testFuzz_calcLpTokenSupply(uint[2] memory _reserves) public {
+        uint[] memory reserves = new uint[](2);
+        reserves[0] = bound(_reserves[0], 1, MAX_RESERVE);
+        reserves[1] = bound(_reserves[1], 1, MAX_RESERVE);
+        uint lpTokenSupply = _function.calcLpTokenSupply(reserves, _data);
+        uint[] memory underlying = _function.calcLPTokenUnderlying(lpTokenSupply, reserves, lpTokenSupply, "");
+        for (uint i = 0; i < reserves.length; ++i) {
+            assertEq(reserves[i], underlying[i], "reserves mismatch");
+        }
+    }
+
+    //////////// FUZZ ////////////
+
+    function testFuzz_constantProduct2(uint x, uint y) public {
         uint[] memory reserves = new uint[](2);
         bytes memory _data = new bytes(0);
-        // TODO - relax assumption
-        reserves[0] = bound(x, 1, 1e32);
-        reserves[1] = bound(y, 1, 1e32);
+
+        reserves[0] = bound(x, 1, MAX_RESERVE);
+        reserves[1] = bound(y, 1, MAX_RESERVE);
+
         uint lpTokenSupply = _function.calcLpTokenSupply(reserves, _data);
-        console.log("lpTokenSupply", lpTokenSupply);
         uint reserve0 = _function.calcReserve(reserves, 0, lpTokenSupply, _data);
         uint reserve1 = _function.calcReserve(reserves, 1, lpTokenSupply, _data);
+
         if (reserves[0] < 1e12) {
             assertApproxEqAbs(reserve0, reserves[0], 2);
         } else {

--- a/test/functions/ConstantProduct2.t.sol
+++ b/test/functions/ConstantProduct2.t.sol
@@ -30,8 +30,8 @@ contract ConstantProduct2Test is WellFunctionHelper {
     }
 
     function test_metadata() public {
-        assertEq(_function.name(), "Constant Product");
-        assertEq(_function.symbol(), "CP");
+        assertEq(_function.name(), "Constant Product 2");
+        assertEq(_function.symbol(), "CP2");
     }
 
     //////////// LP TOKEN SUPPLY ////////////

--- a/test/functions/WellFunctionHelper.sol
+++ b/test/functions/WellFunctionHelper.sol
@@ -12,7 +12,7 @@ abstract contract WellFunctionHelper is TestHelper {
     /// @dev calcLpTokenSupply: 0 reserves = 0 supply
     /// Some Well Functions will choose to support > 2 tokens.
     /// Additional tokens passed in `reserves` should be ignored.
-    function test_getLpTokenSupply_empty(uint n) public {
+    function test_calcLpTokenSupply_empty(uint n) public {
         vm.assume(n < 16);
         vm.assume(n >= 2);
         uint[] memory reserves = new uint[](n);
@@ -20,7 +20,7 @@ abstract contract WellFunctionHelper is TestHelper {
     }
 
     /// @dev require at least `n` reserves to be passed to `calcLpTokenSupply`
-    function check_getLpTokenSupply_minBalancesLength(uint n) public {
+    function check_calcLpTokenSupply_minBalancesLength(uint n) public {
         for (uint i = 0; i < n; ++i) {
             vm.expectRevert(stdError.indexOOBError); // "Index out of bounds"
             _function.calcLpTokenSupply(new uint[](i), _data);


### PR DESCRIPTION
- Fixes [H-3] removeLiquidity logic is not correct for generalized Well functions other than constant product
- Resolves [H-1] Protocol’s invariants can be broken (2)