### PR TITLE
[L-3] Incorrect sload in LibBytes / [NC-01] Non-standard storage packing

### DIFF
--- a/src/libraries/LibBytes.sol
+++ b/src/libraries/LibBytes.sol
@@ -40,7 +40,7 @@ library LibBytes {
             require(reserves[0] <= type(uint128).max, "ByteStorage: too large");
             require(reserves[1] <= type(uint128).max, "ByteStorage: too large");
             assembly {
-                sstore(slot, add(shl(128, mload(add(reserves, 32))), shr(128, shl(128, mload(add(reserves, 64))))))
+                sstore(slot, add(shr(128, shl(128, mload(add(reserves, 32)))), shl(128, mload(add(reserves, 64)))))
             }
         } else {
             uint maxI = reserves.length / 2; // number of fully-packed slots
@@ -53,8 +53,8 @@ library LibBytes {
                     sstore(
                         add(slot, mul(i, 32)),
                         add(
-                            shl(128, mload(add(reserves, add(iByte, 32)))),
-                            shr(128, shl(128, mload(add(reserves, add(iByte, 64)))))
+                            shr(128, shl(128, mload(add(reserves, add(iByte, 32))))),
+                            shl(128, mload(add(reserves, add(iByte, 64))))
                         )
                     )
                 }
@@ -67,7 +67,7 @@ library LibBytes {
                 assembly {
                     sstore(
                         add(slot, mul(maxI, 32)),
-                        add(shl(128, mload(add(reserves, add(iByte, 32)))), shr(128, shl(128, sload(add(slot, maxI)))))
+                        add(shr(128, shl(128, mload(add(reserves, add(iByte, 32))))), shl(128, shr(128, sload(add(slot, mul(maxI, 32))))))
                     )
                 }
             }
@@ -84,8 +84,8 @@ library LibBytes {
         // Shortcut: two reserves can be quickly unpacked from one slot
         if (n == 2) {
             assembly {
-                mstore(add(reserves, 32), shr(128, sload(slot)))
-                mstore(add(reserves, 64), shr(128, shl(128, sload(slot))))
+                mstore(add(reserves, 32), shr(128, shl(128, sload(slot))))
+                mstore(add(reserves, 64), shr(128, sload(slot)))
             }
             return reserves;
         }
@@ -101,12 +101,12 @@ library LibBytes {
                     mstore(
                         // store at index i * 32; i = 0 is skipped by loop
                         add(reserves, mul(i, 32)),
-                        shr(128, sload(add(slot, iByte)))
+                        shr(128, shl(128, sload(add(slot, iByte))))
                     )
                 }
             } else {
                 assembly {
-                    mstore(add(reserves, mul(i, 32)), shr(128, shl(128, sload(add(slot, iByte)))))
+                    mstore(add(reserves, mul(i, 32)), shr(128, sload(add(slot, iByte))))
                 }
             }
         }

--- a/src/libraries/LibBytes.sol
+++ b/src/libraries/LibBytes.sol
@@ -40,7 +40,7 @@ library LibBytes {
             require(reserves[0] <= type(uint128).max, "ByteStorage: too large");
             require(reserves[1] <= type(uint128).max, "ByteStorage: too large");
             assembly {
-                sstore(slot, add(shr(128, shl(128, mload(add(reserves, 32)))), shl(128, mload(add(reserves, 64)))))
+                sstore(slot, add(mload(add(reserves, 32)), shl(128, mload(add(reserves, 64)))))
             }
         } else {
             uint maxI = reserves.length / 2; // number of fully-packed slots
@@ -53,7 +53,7 @@ library LibBytes {
                     sstore(
                         add(slot, mul(i, 32)),
                         add(
-                            shr(128, shl(128, mload(add(reserves, add(iByte, 32))))),
+                            mload(add(reserves, add(iByte, 32))),
                             shl(128, mload(add(reserves, add(iByte, 64))))
                         )
                     )
@@ -67,7 +67,7 @@ library LibBytes {
                 assembly {
                     sstore(
                         add(slot, mul(maxI, 32)),
-                        add(shr(128, shl(128, mload(add(reserves, add(iByte, 32))))), shl(128, shr(128, sload(add(slot, mul(maxI, 32))))))
+                        add(mload(add(reserves, add(iByte, 32))), shl(128, shr(128, sload(add(slot, mul(maxI, 32))))))
                     )
                 }
             }

--- a/test/libraries/LibBytes.t.sol
+++ b/test/libraries/LibBytes.t.sol
@@ -61,4 +61,46 @@ contract LibBytesTest is TestHelper {
         vm.expectRevert("ByteStorage: too large");
         LibBytes.storeUint128(RESERVES_STORAGE_SLOT, reserves);
     }
+
+    function test_exploitStoreAndRead() public {
+        // Write to storage slot to demonstrate overwriting existing values
+        // In this case, 420 will be stored in the lower 128 bits of the last slot
+        bytes32 slot = RESERVES_STORAGE_SLOT;
+        uint maxI = (NUM_RESERVES_MAX - 1) / 2;
+        uint storeValue = 420;
+        assembly {
+            sstore(add(slot, mul(maxI, 32)), shl(128, storeValue))
+        }
+
+        // Read reserves and assert the final reserve is 420
+        uint[] memory reservesBefore = LibBytes.readUint128(RESERVES_STORAGE_SLOT, NUM_RESERVES_MAX);
+        emit log_named_array("reservesBefore", reservesBefore);
+        // Set up reserves to store, but only up to NUM_RESERVES_MAX - 1 as we have already stored a value in the last 128 bits of the last slot
+        uint[] memory reserves = new uint[](NUM_RESERVES_MAX - 1);
+        for (uint i = 1; i < NUM_RESERVES_MAX; i++) {
+            reserves[i - 1] = i;
+        }
+        // Log the last reserve before the store, perhaps from other implementations which don't always act on the entire reserves length
+        uint t;
+        assembly {
+            t := shr(128, sload(add(slot, mul(maxI, 32))))
+        }
+        emit log_named_uint("final slot, lower 128 bits before", t);
+        // Store reserves
+        LibBytes.storeUint128(RESERVES_STORAGE_SLOT, reserves);
+        // Re-read reserves and compare
+        uint[] memory reserves2 = LibBytes.readUint128(RESERVES_STORAGE_SLOT, NUM_RESERVES_MAX);
+
+        emit log_named_array("reserves", reserves);
+        emit log_named_array("reserves2", reserves2);
+
+        // But wait, what about the last reserve
+        assembly {
+            t := shr(128, sload(add(slot, mul(maxI, 32))))
+        }
+
+        // Turns out it was overwritten by the last store as it calculates the sload incorrectly
+        emit log_named_uint("final slot, lower 128 bits after", t);
+        assertEq(t, 420, "Overwrote final slot");
+    }
 }


### PR DESCRIPTION
- Fix [L-3] Incorrect sload in LibBytes
- Fix [NC-01] Non-standard storage packing
- Remove unnecessary shifting operations