### PR TITLE
Implement a more gas efficient mod 2 operation

### DIFF
--- a/src/libraries/LibBytes.sol
+++ b/src/libraries/LibBytes.sol
@@ -61,7 +61,8 @@ library LibBytes {
             }
             // If there is an odd number of reserves, create a slot with the last reserve
             // Since `i < maxI` above, the next byte offset `maxI * 64`
-            if (reserves.length % 2 == 1) {
+            // Equivalent to "i % 2 == 1", but cheaper.
+            if (reserves.length & 1 == 1) {
                 require(reserves[reserves.length - 1] <= type(uint128).max, "ByteStorage: too large");
                 iByte = maxI * 64;
                 assembly {
@@ -96,7 +97,8 @@ library LibBytes {
             // i        1 2 3 4 5 6
             // iByte    0 0 1 1 2 2
             iByte = (i - 1) / 2 * 32;
-            if (i % 2 == 1) {
+            // Equivalent to "i % 2 == 1", but cheaper.
+            if (i & 1 == 1) {
                 assembly {
                     mstore(
                         // store at index i * 32; i = 0 is skipped by loop

--- a/src/libraries/LibBytes16.sol
+++ b/src/libraries/LibBytes16.sol
@@ -36,7 +36,8 @@ library LibBytes16 {
             }
             // If there is an odd number of reserves, create a slot with the last reserve
             // Since `i < maxI` above, the next byte offset `maxI * 64`
-            if (reserves.length % 2 == 1) {
+            // Equivalent to "i % 2 == 1", but cheaper.
+            if (reserves.length & 1 == 1) {
                 iByte = maxI * 64;
                 assembly {
                     sstore(
@@ -70,7 +71,8 @@ library LibBytes16 {
             // i        1 2 3 4 5 6
             // iByte    0 0 1 1 2 2
             iByte = (i - 1) / 2 * 32;
-            if (i % 2 == 1) {
+            // Equivalent to "i % 2 == 1" but cheaper.
+            if (i & 1 == 1) {
                 assembly {
                     mstore(
                         // store at index i * 32; i = 0 is skipped by loop

--- a/src/libraries/LibLastReserveBytes.sol
+++ b/src/libraries/LibLastReserveBytes.sol
@@ -49,7 +49,8 @@ library LibLastReserveBytes {
             }
             // If there is an odd number of reserves, create a slot with the last reserve
             // Since `i < maxI` above, the next byte offset `maxI * 64`
-            if (reserves.length % 2 == 1) {
+            // Equivalent to "i % 2 == 1" but cheaper.
+            if (reserves.length & 1 == 1) {
                 iByte = maxI * 64;
                 assembly {
                     sstore(
@@ -94,7 +95,8 @@ library LibLastReserveBytes {
                 // i        3 4 5 6
                 // iByte    1 1 2 2
                 iByte = (i - 1) / 2 * 32;
-                if (i % 2 == 1) {
+                // Equivalent to "i % 2 == 1" but cheaper.
+                if (i & 1 == 1) {
                     assembly {
                         mstore(
                             // store at index i * 32; i = 0 is skipped by loop

--- a/src/libraries/LibMath.sol
+++ b/src/libraries/LibMath.sol
@@ -17,7 +17,8 @@ library LibMath {
      * https://github.com/cryptoticket/openzeppelin-solidity/blob/04e62a7a1ece4832bee411ca5de024d2ce0b15e6/contracts/math/RoundedDivMath.sol#L31
      */
     function roundedDiv(uint a, uint b) internal pure returns (uint) {
-        uint halfB = (b % 2 == 0) ? (b / 2) : (b / 2 + 1);
+        // Equivalent to "b % 2 == 0" but cheaper.
+        uint halfB = (b & 1 == 0) ? (b / 2) : (b / 2 + 1);
         return (a % b >= halfB) ? (a / b + 1) : (a / b);
     }
 
@@ -37,7 +38,8 @@ library LibMath {
     function nthRoot(uint a, uint n) internal pure returns (uint root) {
         assert(n > 1);
         if (a == 0) return 0;
-        if (n % 2 == 0) {
+        // Equivalent to "i % 2 == 0" but cheaper.
+        if (n & 1 == 0) {
             if (n == 2) return sqrt(a); // shortcut for square root
             if (n == 4) return sqrt(sqrt(a));
             if (n == 8) return sqrt(sqrt(sqrt(a)));

--- a/test/libraries/LibBytes.t.sol
+++ b/test/libraries/LibBytes.t.sol
@@ -26,6 +26,21 @@ contract LibBytesTest is TestHelper {
             assertEq(reserves2[i], reserves[i], "ByteStorage: reserves mismatch");
         }
     }
+    
+    function testStoreAndRead() public {
+        uint n = 2;
+        uint[] memory reserves = new uint[](n);
+        for (uint i = 0; i < n; i++) {
+            reserves[i] = i * 100 + 1;
+        }
+        LibBytes.storeUint128(RESERVES_STORAGE_SLOT, reserves);
+
+        // Re-read reserves and compare
+        uint[] memory reserves2 = LibBytes.readUint128(RESERVES_STORAGE_SLOT, n);
+        for (uint i = 0; i < reserves2.length; i++) {
+            assertEq(reserves2[i], reserves[i], "ByteStorage: reserves mismatch");
+        }
+    }
 
     /// @dev Test every size of reserves array and every position for overflow
     /// All reserves besides `reserves[j]` are zero.


### PR DESCRIPTION
Replace instances of:
- `x % 2 == 1` with `x & 1 == 1`
- and
- `x % 2 == 0` with `x & 1 == 0`