### PR TITLE
Add minLpAmountOut to `sync`

### DIFF
--- a/src/Well.sol
+++ b/src/Well.sol
@@ -619,10 +619,8 @@ contract Well is ERC20PermitUpgradeable, IWell, IWellErrors, ReentrancyGuardUpgr
     //////////////////// RESERVES ////////////////////
 
     /**
-     * @dev Sync the reserves of the Well with its current balance of underlying tokens
-     * and mints at least `minLpAmountOut` LP tokens to `recipient` if the reserves increased. Can be used in a
-     * multicall to add liquidity similar to how `shift` can be used to swap in a multicall.
-     * See {shift} for examples of how to use this function in a multicall.
+     * @dev Can be used in a multicall to add liquidity similar to how `shift` can be used to swap in a multicall.
+     * See {shift} for examples of how to use in a multicall.
      */
     function sync(address recipient, uint256 minLpAmountOut) external nonReentrant returns (uint256 lpAmountOut) {
         IERC20[] memory _tokens = tokens();

--- a/src/Well.sol
+++ b/src/Well.sol
@@ -620,8 +620,9 @@ contract Well is ERC20PermitUpgradeable, IWell, IWellErrors, ReentrancyGuardUpgr
 
     /**
      * @dev Sync the reserves of the Well with its current balance of underlying tokens
-     * and mints LP tokens to `recipient` if the reserves increased. Can be used in a
+     * and mints at least `minLpAmountOut` LP tokens to `recipient` if the reserves increased. Can be used in a
      * multicall to add liquidity similar to how `shift` can be used to swap in a multicall.
+     * See {shift} for examples of how to use this function in a multicall.
      */
     function sync(address recipient, uint256 minLpAmountOut) external nonReentrant returns (uint256 lpAmountOut) {
         IERC20[] memory _tokens = tokens();

--- a/src/Well.sol
+++ b/src/Well.sol
@@ -619,7 +619,7 @@ contract Well is ERC20PermitUpgradeable, IWell, IWellErrors, ReentrancyGuardUpgr
     //////////////////// RESERVES ////////////////////
 
     /**
-     * @dev Can be used in a multicall to add liquidity similar to how `shift` can be used to swap in a multicall.
+     * @dev Can be used in a multicall to add liquidity similar to how `shift` can be used to swap.
      * See {shift} for examples of how to use in a multicall.
      */
     function sync(address recipient, uint256 minLpAmountOut) external nonReentrant returns (uint256 lpAmountOut) {

--- a/src/interfaces/IWell.sol
+++ b/src/interfaces/IWell.sol
@@ -227,7 +227,7 @@ interface IWell {
      * @param minAmountOut The minimum amount of `tokenOut` to receive
      * @param recipient The address to receive the token
      * @return amountOut The amount of `tokenOut` received
-     * @dev Can be used in a multicall contract like Pipeline to perform a gas efficient swap.
+     * @dev Can be used in a multicall using a contract like Pipeline to perform a gas efficient swap.
      * No deadline is needed since this function does not use the user's assets. If adding liquidity in a multicall,
      * then a deadline check can be added to the multicall.
      * When swapping through a multicall, use `minAmountOut` to protect against MEV.
@@ -371,7 +371,7 @@ interface IWell {
      * @param recipient The address to receive the LP tokens
      * @param minLpAmountOut The minimum amount of LP tokens to receive
      * @return lpAmountOut The amount of LP tokens received
-     * @dev Can be used in a multicall contract like Pipeline to perform gas efficient add liquidity operations.
+     * @dev Can be used in a multicall using a contract like Pipeline to perform gas efficient add liquidity operations.
      * No deadline is needed since this function does not use the user's assets. If adding liquidity in a multicall,
      * then a deadline check can be added to the multicall.
      * When adding liquidity through a multicall, use `minLpAmountOut` to protect against MEV.

--- a/src/interfaces/IWell.sol
+++ b/src/interfaces/IWell.sol
@@ -365,8 +365,8 @@ interface IWell {
     //////////////////// RESERVES ////////////////////
 
     /**
-     * @notice Syncs the reserves of the Well with the Well's balances of underlying tokens and if the reserves
-     * increase mints at least `minLpAmountOut` LP Tokens to `recipient`.
+     * @notice Syncs the reserves of the Well with the Well's balances of underlying tokens. If the reserves
+     * increasem, mints at least `minLpAmountOut` LP Tokens to `recipient`.
      * @param recipient The address to receive the LP tokens
      * @param minLpAmountOut The minimum amount of LP tokens to receive
      * @return lpAmountOut The amount of LP tokens received

--- a/src/interfaces/IWell.sol
+++ b/src/interfaces/IWell.sol
@@ -222,7 +222,7 @@ interface IWell {
     //////////////////// SHIFT ////////////////////
 
     /**
-     * @notice Shifts excess tokens held by the Well into `tokenOut` and delivers to `recipient`.
+     * @notice Shifts at least `minAmountOut` excess tokens held by the Well into `tokenOut` and delivers to `recipient`.
      * @param tokenOut The token to shift into
      * @param minAmountOut The minimum amount of `tokenOut` to receive
      * @param recipient The address to receive the token
@@ -365,7 +365,7 @@ interface IWell {
     //////////////////// RESERVES ////////////////////
 
     /**
-     * @notice Syncs the reserves of the Well with the Well's balances of underlying tokens. If the reserves
+     * @notice Syncs the Well's reserves with the Well's balances of underlying tokens. If the reserves
      * increase, mints at least `minLpAmountOut` LP Tokens to `recipient`.
      * @param recipient The address to receive the LP tokens
      * @param minLpAmountOut The minimum amount of LP tokens to receive
@@ -373,7 +373,7 @@ interface IWell {
      * @dev Can be used in a multicall using a contract like Pipeline to perform gas efficient additions of liquidity.
      * No deadline is needed since this function does not use the user's assets. If adding liquidity in a multicall,
      * then a deadline check can be added to the multicall.
-     * If `sync` decreases the Well's reserve balances, then no LP tokens are minted and `lpAmountOut` must be 0.
+     * If `sync` decreases the Well's reserves, then no LP tokens are minted and `lpAmountOut` must be 0.
      */
     function sync(address recipient, uint256 minLpAmountOut) external returns (uint256 lpAmountOut);
 

--- a/src/interfaces/IWell.sol
+++ b/src/interfaces/IWell.sol
@@ -227,7 +227,7 @@ interface IWell {
      * @param minAmountOut The minimum amount of `tokenOut` to receive
      * @param recipient The address to receive the token
      * @return amountOut The amount of `tokenOut` received
-     * @dev Can be used in a multicall using a contract like Pipeline to perform a gas efficient swap.
+     * @dev Can be used in a multicall using a contract like Pipeline to perform gas efficient swaps.
      * No deadline is needed since this function does not use the user's assets. If adding liquidity in a multicall,
      * then a deadline check can be added to the multicall.
      */
@@ -369,8 +369,8 @@ interface IWell {
      * increase mints at least `minLpAmountOut` LP Tokens to `recipient`.
      * @param recipient The address to receive the LP tokens
      * @param minLpAmountOut The minimum amount of LP tokens to receive
-     * @return lpAmountOut The amount of LP tokens receivedWeh
-     * @dev Can be used in a multicall using a contract like Pipeline to perform gas efficient add liquidity operations.
+     * @return lpAmountOut The amount of LP tokens received
+     * @dev Can be used in a multicall using a contract like Pipeline to perform gas efficient additions of liquidity.
      * No deadline is needed since this function does not use the user's assets. If adding liquidity in a multicall,
      * then a deadline check can be added to the multicall.
      * If `sync` decreases the Well's reserve balances, then no LP tokens are minted and `lpAmountOut` must be 0.

--- a/src/interfaces/IWell.sol
+++ b/src/interfaces/IWell.sol
@@ -227,9 +227,10 @@ interface IWell {
      * @param minAmountOut The minimum amount of `tokenOut` to receive
      * @param recipient The address to receive the token
      * @return amountOut The amount of `tokenOut` received
-     * @dev No deadline is needed since this function does not use the user's assets. If used with
-     * with a multicall contract like Pipeline to perform a swap, a deadline check could be added
-     * to the multicall.
+     * @dev Can be used in a multicall contract like Pipeline to perform a gas efficient swap.
+     * No deadline is needed since this function does not use the user's assets. If adding liquidity in a multicall,
+     * then a deadline check can be added to the multicall.
+     * When swapping through a multicall, use `minAmountOut` to protect against MEV.
      */
     function shift(IERC20 tokenOut, uint256 minAmountOut, address recipient) external returns (uint256 amountOut);
 

--- a/src/interfaces/IWell.sol
+++ b/src/interfaces/IWell.sol
@@ -366,7 +366,7 @@ interface IWell {
 
     /**
      * @notice Syncs the reserves of the Well with the Well's balances of underlying tokens. If the reserves
-     * increasem, mints at least `minLpAmountOut` LP Tokens to `recipient`.
+     * increase, mints at least `minLpAmountOut` LP Tokens to `recipient`.
      * @param recipient The address to receive the LP tokens
      * @param minLpAmountOut The minimum amount of LP tokens to receive
      * @return lpAmountOut The amount of LP tokens received

--- a/src/interfaces/IWell.sol
+++ b/src/interfaces/IWell.sol
@@ -230,7 +230,6 @@ interface IWell {
      * @dev Can be used in a multicall using a contract like Pipeline to perform a gas efficient swap.
      * No deadline is needed since this function does not use the user's assets. If adding liquidity in a multicall,
      * then a deadline check can be added to the multicall.
-     * When swapping through a multicall, use `minAmountOut` to protect against MEV.
      */
     function shift(IERC20 tokenOut, uint256 minAmountOut, address recipient) external returns (uint256 amountOut);
 
@@ -370,11 +369,10 @@ interface IWell {
      * mints at least `minLpAmountOut` LP Tokens to `recipient` if the reserves increased.
      * @param recipient The address to receive the LP tokens
      * @param minLpAmountOut The minimum amount of LP tokens to receive
-     * @return lpAmountOut The amount of LP tokens received
+     * @return lpAmountOut The amount of LP tokens receivedWeh
      * @dev Can be used in a multicall using a contract like Pipeline to perform gas efficient add liquidity operations.
      * No deadline is needed since this function does not use the user's assets. If adding liquidity in a multicall,
      * then a deadline check can be added to the multicall.
-     * When adding liquidity through a multicall, use `minLpAmountOut` to protect against MEV.
      */
     function sync(address recipient, uint256 minLpAmountOut) external returns (uint256 lpAmountOut);
 

--- a/src/interfaces/IWell.sol
+++ b/src/interfaces/IWell.sol
@@ -371,7 +371,7 @@ interface IWell {
      * @param recipient The address to receive the LP tokens
      * @param minLpAmountOut The minimum amount of LP tokens to receive
      * @return lpAmountOut The amount of LP tokens received
-     * @dev Can be used in a multicall contract like Pipeline to perform a gas efficient add liquidity operation.
+     * @dev Can be used in a multicall contract like Pipeline to perform gas efficient add liquidity operations.
      * No deadline is needed since this function does not use the user's assets. If adding liquidity in a multicall,
      * then a deadline check can be added to the multicall.
      * When adding liquidity through a multicall, use `minLpAmountOut` to protect against MEV.

--- a/src/interfaces/IWell.sol
+++ b/src/interfaces/IWell.sol
@@ -365,14 +365,15 @@ interface IWell {
     //////////////////// RESERVES ////////////////////
 
     /**
-     * @notice Syncs the reserves of the Well with the Well's balances of underlying tokens and mints LP tokens and
-     * mints at least `minLpAmountOut` LP Tokens to `recipient` if the reserves increased.
+     * @notice Syncs the reserves of the Well with the Well's balances of underlying tokens and if the reserves
+     * increase mints at least `minLpAmountOut` LP Tokens to `recipient`.
      * @param recipient The address to receive the LP tokens
      * @param minLpAmountOut The minimum amount of LP tokens to receive
      * @return lpAmountOut The amount of LP tokens receivedWeh
      * @dev Can be used in a multicall using a contract like Pipeline to perform gas efficient add liquidity operations.
      * No deadline is needed since this function does not use the user's assets. If adding liquidity in a multicall,
      * then a deadline check can be added to the multicall.
+     * If `sync` decreases the Well's reserve balances, then no LP tokens are minted and `lpAmountOut` must be 0.
      */
     function sync(address recipient, uint256 minLpAmountOut) external returns (uint256 lpAmountOut);
 

--- a/src/interfaces/IWell.sol
+++ b/src/interfaces/IWell.sol
@@ -367,12 +367,14 @@ interface IWell {
     /**
      * @notice Syncs the reserves of the Well with the Well's balances of underlying tokens.
      * @param recipient The address to receive the LP tokens
+     * @param minLpAmountOut The minimum amount of LP tokens to receive
      * @return lpAmountOut The amount of LP tokens received
-     * @dev No deadline is needed since this function does not use the user's assets. If used with
-     * with a multicall contract like Pipeline to perform add liquidity, a deadline check could be
-     * added to the multicall.
+     * @dev Can be used in a multicall contract like Pipeline to perform a gas efficient add liquidity operation.
+     * No deadline is needed since this function does not use the user's assets. If adding liquidity in a multicall,
+     * then a deadline check can be added to the multicall.
+     * When adding liquidity through a multicall, use `minLpAmountOut` to protect against MEV.
      */
-    function sync(address recipient) external returns (uint256 lpAmountOut);
+    function sync(address recipient, uint256 minLpAmountOut) external returns (uint256 lpAmountOut);
 
     /**
      * @notice Sends excess tokens held by the Well to the `recipient`.

--- a/src/interfaces/IWell.sol
+++ b/src/interfaces/IWell.sol
@@ -366,7 +366,8 @@ interface IWell {
     //////////////////// RESERVES ////////////////////
 
     /**
-     * @notice Syncs the reserves of the Well with the Well's balances of underlying tokens.
+     * @notice Syncs the reserves of the Well with the Well's balances of underlying tokens and mints LP tokens and
+     * mints at least `minLpAmountOut` LP Tokens to `recipient` if the reserves increased.
      * @param recipient The address to receive the LP tokens
      * @param minLpAmountOut The minimum amount of LP tokens to receive
      * @return lpAmountOut The amount of LP tokens received

--- a/test/Well.Sync.t.sol
+++ b/test/Well.Sync.t.sol
@@ -23,7 +23,7 @@ contract WellSyncTest is TestHelper {
         assertEq(wellBalance.tokens[1], 1000 * 1e18);
     }
 
-    function test_syncDown_revert_minAmountOutTooHigh() public prank(user) {
+    function test_syncDown() public prank(user) {
         MockToken(address(tokens[0])).burnFrom(address(well), 1e18);
         MockToken(address(tokens[1])).burnFrom(address(well), 1e18);
 
@@ -45,7 +45,7 @@ contract WellSyncTest is TestHelper {
         assertEq(lpAmountOut, 0, "return value should be 0");
     }
 
-    function test_syncDown() public prank(user) {
+    function test_syncDown_revert_minAmountOutTooHigh() public prank(user) {
         MockToken(address(tokens[0])).burnFrom(address(well), 1e18);
         MockToken(address(tokens[1])).burnFrom(address(well), 1e18);
         vm.expectRevert(abi.encodeWithSelector(IWellErrors.SlippageOut.selector, 0, 1));

--- a/test/invariant/Handler.t.sol
+++ b/test/invariant/Handler.t.sol
@@ -360,7 +360,7 @@ contract Handler is Test {
     function sync() public {
         console.log("----------------------------------");
         console.log("Sync");
-        s_well.sync(address(this));
+        s_well.sync(address(this), 0);
         printWellTokenValues();
     }
 


### PR DESCRIPTION
`sync` now mints liquidity to `recipient`. This allows it to be used in to add liquidity in a gas efficient manor.  A`minLpAmountOut` parameter has been added to protect against MEV.