### PR TITLE
Fix via ir Tests

### DIFF
--- a/src/libraries/LibWellConstructor.sol
+++ b/src/libraries/LibWellConstructor.sol
@@ -39,16 +39,6 @@ library LibWellConstructor {
         Call memory _wellFunction,
         Call[] memory _pumps
     ) internal pure returns (bytes memory immutableData) {
-        bytes memory packedPumps;
-        for (uint256 i; i < _pumps.length; ++i) {
-            Call memory _pump = _pumps[i];
-            packedPumps = abi.encodePacked(
-                packedPumps,            // previously packed pumps
-                _pump.target,       // pump address
-                _pump.data.length,  // pump data length
-                _pump.data          // pump data (bytes)
-            );
-        }
         
         immutableData = abi.encodePacked(
             _aquifer,                   // aquifer address
@@ -57,9 +47,16 @@ library LibWellConstructor {
             _wellFunction.data.length,  // well function data length
             _pumps.length,              // number of pumps
             _tokens,                    // tokens array
-            _wellFunction.data,         // well function data (bytes)
-            packedPumps                 // packed pumps (bytes)
+            _wellFunction.data         // well function data (bytes)
         );
+        for (uint256 i; i < _pumps.length; ++i) {
+            immutableData = abi.encodePacked(
+                immutableData,            // previously packed pumps
+                _pumps[i].target,       // pump address
+                _pumps[i].data.length,  // pump data length
+                _pumps[i].data          // pump data (bytes)
+            );
+        }
     }
 
     /**

--- a/test/pumps/Pump.Fuzz.t.sol
+++ b/test/pumps/Pump.Fuzz.t.sol
@@ -67,7 +67,6 @@ contract PumpFuzzTest is TestHelper, MultiFlowPump {
 
         // Read a snapshot from the Pump
         bytes memory startCumulativeReserves = pump.readCumulativeReserves(address(mWell), new bytes(0));
-        uint256 startTimestamp = block.timestamp;
 
         // Fast-forward time and update the Pump with new reserves.
         increaseTime(timeIncrease);
@@ -100,8 +99,9 @@ contract PumpFuzzTest is TestHelper, MultiFlowPump {
 
         // readTwaReserves reverts if no time has passed.
         if (timeIncrease > 0) {
-            (uint256[] memory twaReserves,) =
-                pump.readTwaReserves(address(mWell), startCumulativeReserves, startTimestamp, new bytes(0));
+            (uint256[] memory twaReserves,) = pump.readTwaReserves(
+                address(mWell), startCumulativeReserves, block.timestamp - timeIncrease, new bytes(0)
+            );
             for (uint256 i; i < n; ++i) {
                 console.log("TWA RESERVES", i, twaReserves[i]);
                 if (lastReserves[i] > 1e24) {

--- a/test/pumps/Pump.TimeWeightedAverage.t.sol
+++ b/test/pumps/Pump.TimeWeightedAverage.t.sol
@@ -45,8 +45,6 @@ contract PumpTimeWeightedAverageTest is TestHelper {
         increaseTime(12);
 
         bytes memory startCumulativeReserves = pump.readCumulativeReserves(address(mWell), "");
-        uint256 startTimestamp = block.timestamp;
-
         uint256[] memory lastReserves = pump.readLastCappedReserves(address(mWell));
 
         assertApproxEqAbs(lastReserves[0], 1e6, 1);
@@ -55,7 +53,7 @@ contract PumpTimeWeightedAverageTest is TestHelper {
         increaseTime(120);
         uint256[] memory twaReserves;
 
-        (twaReserves,) = pump.readTwaReserves(address(mWell), startCumulativeReserves, startTimestamp, "");
+        (twaReserves,) = pump.readTwaReserves(address(mWell), startCumulativeReserves, block.timestamp - 120, "");
 
         assertApproxEqAbs(twaReserves[0], 1e6, 1);
         assertApproxEqAbs(twaReserves[1], 2e6, 1);
@@ -66,7 +64,7 @@ contract PumpTimeWeightedAverageTest is TestHelper {
 
         increaseTime(120);
 
-        (twaReserves,) = pump.readTwaReserves(address(mWell), startCumulativeReserves, startTimestamp, "");
+        (twaReserves,) = pump.readTwaReserves(address(mWell), startCumulativeReserves, block.timestamp - 240, "");
 
         assertEq(twaReserves[0], 1_414_213); // Geometric Mean of 1e6 and 2e6 is 1_414_213
         assertEq(twaReserves[1], 2_828_427); // Geometric mean of 2e6 and 4e6 is 2_828_427

--- a/test/pumps/Pump.Update.t.sol
+++ b/test/pumps/Pump.Update.t.sol
@@ -106,7 +106,6 @@ contract PumpUpdateTest is TestHelper {
 
     function test_update_12Seconds() public prank(user) {
         bytes memory startCumulativeReserves = pump.readCumulativeReserves(address(mWell), new bytes(0));
-        uint256 lastTimestamp = block.timestamp;
         // After CAP_INTERVAL, Pump receives an update
         b[0] = 2e6; // 1e6 -> 2e6 = +100%
         b[1] = 1e6; // 2e6 -> 1e6 = - 50%
@@ -142,7 +141,7 @@ contract PumpUpdateTest is TestHelper {
         assertApproxEqAbs(cumulativeReserves[1].div(ABDKMathQuad.fromUInt(12)).pow_2().toUInt(), 1e6, 1);
 
         (uint256[] memory twaReserves, bytes memory twaCumulativeReservesBytes) =
-            pump.readTwaReserves(address(mWell), startCumulativeReserves, lastTimestamp, new bytes(0));
+            pump.readTwaReserves(address(mWell), startCumulativeReserves, block.timestamp - CAP_INTERVAL, new bytes(0));
 
         assertApproxEqAbs(twaReserves[0], 1.5e6, 1);
         assertApproxEqAbs(twaReserves[1], 1e6, 1);
@@ -154,7 +153,6 @@ contract PumpUpdateTest is TestHelper {
 
     function test_12Seconds_read() public prank(user) {
         bytes memory startCumulativeReserves = pump.readCumulativeReserves(address(mWell), new bytes(0));
-        uint256 lastTimestamp = block.timestamp;
 
         b[0] = 2e6; // 1e6 -> 2e6 = +100%
         b[1] = 1e6; // 2e6 -> 1e6 = - 50%
@@ -162,7 +160,6 @@ contract PumpUpdateTest is TestHelper {
 
         increaseTime(CAP_INTERVAL);
 
-        //
         uint256[] memory emaReserves = pump.readInstantaneousReserves(address(mWell), new bytes(0));
         assertEq(emaReserves[0], 1_337_697);
         assertEq(emaReserves[1], 1_216_241);
@@ -173,7 +170,7 @@ contract PumpUpdateTest is TestHelper {
         assertApproxEqAbs(cumulativeReserves[1].div(ABDKMathQuad.fromUInt(12)).pow_2().toUInt(), 1e6, 1);
 
         (uint256[] memory twaReserves, bytes memory twaCumulativeReservesBytes) =
-            pump.readTwaReserves(address(mWell), startCumulativeReserves, lastTimestamp, new bytes(0));
+            pump.readTwaReserves(address(mWell), startCumulativeReserves, block.timestamp - CAP_INTERVAL, new bytes(0));
 
         assertApproxEqAbs(twaReserves[0], 1.5e6, 1);
         assertApproxEqAbs(twaReserves[1], 1e6, 1);
@@ -185,7 +182,6 @@ contract PumpUpdateTest is TestHelper {
 
     function test_12seconds_update_12Seconds_update() public prank(user) {
         bytes memory startCumulativeReserves = pump.readCumulativeReserves(address(mWell), new bytes(0));
-        uint256 lastTimestamp = block.timestamp;
 
         b[0] = 2e6; // 1e6 -> 2e6 = +100%
         b[1] = 1e6; // 2e6 -> 1e6 = - 50%
@@ -195,7 +191,6 @@ contract PumpUpdateTest is TestHelper {
         increaseTime(CAP_INTERVAL);
 
         bytes memory startCumulativeReserves2 = pump.readCumulativeReserves(address(mWell), new bytes(0));
-        uint256 lastTimestamp2 = block.timestamp;
 
         b[0] = 1e6; // 1e6 -> 2e6 = +100%
         b[1] = 2e6; // 2e6 -> 1e6 = - 50%
@@ -231,8 +226,9 @@ contract PumpUpdateTest is TestHelper {
         assertApproxEqAbs(cumulativeReserves[0].div(ABDKMathQuad.fromUInt(24)).pow_2().toUInt(), 1_224_744, 1);
         assertApproxEqAbs(cumulativeReserves[1].div(ABDKMathQuad.fromUInt(24)).pow_2().toUInt(), 1_224_744, 1);
 
-        (uint256[] memory twaReserves, bytes memory twaCumulativeReservesBytes) =
-            pump.readTwaReserves(address(mWell), startCumulativeReserves, lastTimestamp, new bytes(0));
+        (uint256[] memory twaReserves, bytes memory twaCumulativeReservesBytes) = pump.readTwaReserves(
+            address(mWell), startCumulativeReserves, block.timestamp - 2 * CAP_INTERVAL, new bytes(0)
+        );
 
         assertApproxEqAbs(twaReserves[0], 1_224_744, 1);
         assertApproxEqAbs(twaReserves[1], 1_224_744, 1);
@@ -242,7 +238,7 @@ contract PumpUpdateTest is TestHelper {
         assertApproxEqAbs(cumulativeReserves[1].div(ABDKMathQuad.fromUInt(24)).pow_2().toUInt(), 1_224_744, 1);
 
         (twaReserves, twaCumulativeReservesBytes) =
-            pump.readTwaReserves(address(mWell), startCumulativeReserves2, lastTimestamp2, new bytes(0));
+            pump.readTwaReserves(address(mWell), startCumulativeReserves2, block.timestamp - CAP_INTERVAL, new bytes(0));
 
         assertApproxEqAbs(twaReserves[0], 1e6, 1);
         assertApproxEqAbs(twaReserves[1], 1.5e6, 1);
@@ -254,7 +250,6 @@ contract PumpUpdateTest is TestHelper {
 
     function test_12seconds_update_12Seconds_read() public prank(user) {
         bytes memory startCumulativeReserves = pump.readCumulativeReserves(address(mWell), new bytes(0));
-        uint256 lastTimestamp = block.timestamp;
 
         b[0] = 2e6; // 1e6 -> 2e6 = +100%
         b[1] = 1e6; // 2e6 -> 1e6 = - 50%
@@ -264,7 +259,6 @@ contract PumpUpdateTest is TestHelper {
         increaseTime(CAP_INTERVAL);
 
         bytes memory startCumulativeReserves2 = pump.readCumulativeReserves(address(mWell), new bytes(0));
-        uint256 lastTimestamp2 = block.timestamp;
 
         b[0] = 1e6; // 1e6 -> 2e6 = +100%
         b[1] = 2e6; // 2e6 -> 1e6 = - 50%
@@ -282,8 +276,9 @@ contract PumpUpdateTest is TestHelper {
         assertApproxEqAbs(cumulativeReserves[0].div(ABDKMathQuad.fromUInt(24)).pow_2().toUInt(), 1_224_744, 1);
         assertApproxEqAbs(cumulativeReserves[1].div(ABDKMathQuad.fromUInt(24)).pow_2().toUInt(), 1_224_744, 1);
 
-        (uint256[] memory twaReserves, bytes memory twaCumulativeReservesBytes) =
-            pump.readTwaReserves(address(mWell), startCumulativeReserves, lastTimestamp, new bytes(0));
+        (uint256[] memory twaReserves, bytes memory twaCumulativeReservesBytes) = pump.readTwaReserves(
+            address(mWell), startCumulativeReserves, block.timestamp - 2 * CAP_INTERVAL, new bytes(0)
+        );
 
         assertApproxEqAbs(twaReserves[0], 1_224_744, 1);
         assertApproxEqAbs(twaReserves[1], 1_224_744, 1);
@@ -293,7 +288,7 @@ contract PumpUpdateTest is TestHelper {
         assertApproxEqAbs(cumulativeReserves[1].div(ABDKMathQuad.fromUInt(24)).pow_2().toUInt(), 1_224_744, 1);
 
         (twaReserves, twaCumulativeReservesBytes) =
-            pump.readTwaReserves(address(mWell), startCumulativeReserves2, lastTimestamp2, new bytes(0));
+            pump.readTwaReserves(address(mWell), startCumulativeReserves2, block.timestamp - CAP_INTERVAL, new bytes(0));
 
         assertApproxEqAbs(twaReserves[0], 1e6, 1);
         assertApproxEqAbs(twaReserves[1], 1.5e6, 1);


### PR DESCRIPTION
Fix tests that fail with the `--via-ir` flag. There seems to be a bug that causes tests that evaluate the delta timestamp to break.