### PR TITLE
Update wellUpgradable Implementation

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -4,7 +4,7 @@ out = 'out'
 libs = ['lib', 'node_modules']
 fuzz = { runs = 256 }
 optimizer = true
-optimizer_runs = 800
+optimizer_runs = 400
 remappings = [
   '@openzeppelin/=node_modules/@openzeppelin/',
 ]


### PR DESCRIPTION
- reduces optimizer from 800 to 400 to support upgradeable wells. 
- implements `_authorizeUpgrade` and `upgradeTo` to support ERC1167 minimal proxies deployed by an aquifer. Restricts upgrades to wells bored by an aquifer.