### PR TITLE
Update wellUpgradable Implementation

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -4,7 +4,7 @@ out = 'out'
 libs = ['lib', 'node_modules']
 fuzz = { runs = 256 }
 optimizer = true
-optimizer_runs = 800
+optimizer_runs = 400
 remappings = [
   '@openzeppelin/=node_modules/@openzeppelin/',
 ]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@beanstalk/wells",
-  "version": "1.1.0-prerelease0",
+  "version": "1.2.0-prerelease0",
   "description": "A [{Well}](/src/Well.sol) is a constant function AMM that allows the provisioning of liquidity into a single pooled on-chain liquidity position.",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
- reduces optimizer from 800 to 400 to support upgradeable wells. 
- implements `_authorizeUpgrade` and `upgradeTo` to support ERC1167 minimal proxies bored by an aquifer. 
- restricts upgrades to wells bored by an aquifer.