### PR TITLE
MultiFlow Pump v1.1 remediation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 cache/
 out/
 
+.vscode
+
 # Ignores development broadcast logs
 /broadcast
 

--- a/foundry.toml
+++ b/foundry.toml
@@ -4,7 +4,7 @@ out = 'out'
 libs = ['lib', 'node_modules']
 fuzz = { runs = 256 }
 optimizer = true
-optimizer_runs = 800
+optimizer_runs = 400
 remappings = [
   '@openzeppelin/=node_modules/@openzeppelin/',
 ]

--- a/mocks/wells/MockWellUpgradeable.sol
+++ b/mocks/wells/MockWellUpgradeable.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.20;
+
+import {WellUpgradeable} from "src/WellUpgradeable.sol";
+
+// this needs to be here for upgrade checks
+/// @custom:oz-upgrades-from WellUpgradeable
+contract MockWellUpgradeable is WellUpgradeable {
+
+    function getVersion(uint256 i) external pure returns (uint256) {
+        return i;
+    }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@beanstalk/wells",
-  "version": "1.1.0-prerelease0",
+  "version": "1.2.0-prerelease0",
   "description": "A [{Well}](/src/Well.sol) is a constant function AMM that allows the provisioning of liquidity into a single pooled on-chain liquidity position.",
   "main": "index.js",
   "directories": {

--- a/script/helpers/WellDeployer.sol
+++ b/script/helpers/WellDeployer.sol
@@ -5,6 +5,8 @@ import {LibContractInfo} from "src/libraries/LibContractInfo.sol";
 import {LibWellConstructor} from "src/libraries/LibWellConstructor.sol";
 import {Well, Call, IERC20} from "src/Well.sol";
 import {Aquifer} from "src/Aquifer.sol";
+import {WellUpgradeable} from "src/WellUpgradeable.sol";
+import {LibWellUpgradeableConstructor} from "src/libraries/LibWellUpgradeableConstructor.sol";
 
 abstract contract WellDeployer {
     /**
@@ -27,5 +29,28 @@ abstract contract WellDeployer {
         (bytes memory immutableData, bytes memory initData) =
             LibWellConstructor.encodeWellDeploymentData(_aquifer, _tokens, _wellFunction, _pumps);
         _well = Well(Aquifer(_aquifer).boreWell(_wellImplementation, immutableData, initData, _salt));
+    }
+
+
+    /**
+     * @notice Encode the Well's immutable data, and deploys the well. Modified for upgradeable wells.
+     * @param _aquifer The address of the Aquifer which will deploy this Well.
+     * @param _wellImplementation The address of the Well implementation.
+     * @param _tokens A list of ERC20 tokens supported by the Well.
+     * @param _wellFunction A single Call struct representing a call to the Well Function.
+     * @param _pumps An array of Call structs representings calls to Pumps.
+     * @param _salt The salt to deploy the Well with (`bytes32(0)` for none). See {LibClone}.
+     */
+    function encodeAndBoreWellUpgradeable(
+        address _aquifer,
+        address _wellImplementation,
+        IERC20[] memory _tokens,
+        Call memory _wellFunction,
+        Call[] memory _pumps,
+        bytes32 _salt
+    ) internal returns (WellUpgradeable _well) {
+        (bytes memory immutableData, bytes memory initData) =
+            LibWellUpgradeableConstructor.encodeWellDeploymentData(_aquifer, _tokens, _wellFunction, _pumps);
+        _well = WellUpgradeable(Aquifer(_aquifer).boreWell(_wellImplementation, immutableData, initData, _salt));
     }
 }

--- a/src/Well.sol
+++ b/src/Well.sol
@@ -44,7 +44,7 @@ contract Well is ERC20PermitUpgradeable, IWell, IWellErrors, ReentrancyGuardUpgr
         _disableInitializers();
     }
 
-    function init(string memory _name, string memory _symbol) external initializer {
+    function init(string memory _name, string memory _symbol) external virtual initializer {
         __ERC20Permit_init(_name);
         __ERC20_init(_name, _symbol);
         __ReentrancyGuard_init();

--- a/src/WellUpgradeable.sol
+++ b/src/WellUpgradeable.sol
@@ -1,0 +1,163 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.20;
+
+import {Well} from "src/Well.sol";
+import {UUPSUpgradeable} from "ozu/proxy/utils/UUPSUpgradeable.sol";
+import {OwnableUpgradeable} from "ozu/access/OwnableUpgradeable.sol";
+import {IERC20, SafeERC20} from "oz/token/ERC20/utils/SafeERC20.sol";
+import {IAquifer} from "src/interfaces/IAquifer.sol";
+import {console} from "forge-std/console.sol";
+
+/**
+ * @title WellUpgradeable
+ * @author Publius, Silo Chad, Brean, Deadmanwalking
+ * @dev A Well is a constant function AMM allowing the provisioning of liquidity
+ * into a single pooled on-chain liquidity position.
+ *
+ * Given the dynamic storage layout of Wells initialized by an minimal proxy,
+ * Creating an upgradeable Well requires a custom initializer function that allows the Well
+ * to be initialized with immutable storage, but does not deploy a Well token.
+ *
+ * Rebasing Tokens:
+ * - Positive rebasing tokens are supported by Wells, but any tokens recieved from a
+ *   rebase will not be rewarded to LP holders and instead can be extracted by anyone
+ *   using `skim`, `sync` or `shift`.
+ * - Negative rebasing tokens should not be used in Well as the effect of a negative
+ *   rebase will be realized by users interacting with the Well, not LP token holders.
+ *
+ * Fee on Tranfer (FoT) Tokens:
+ * - When transferring fee on transfer tokens to a Well (swapping from or adding liquidity),
+ *   use `swapFromFeeOnTrasfer` or `addLiquidityFeeOnTransfer`. `swapTo` does not support
+ *   fee on transfer tokens (See {swapTo}).
+ * - When recieving fee on transfer tokens from a Well (swapping to and removing liquidity),
+ *   INCLUDE the fee that is taken on transfer when calculating amount out values.
+ */
+contract WellUpgradeable is Well, UUPSUpgradeable, OwnableUpgradeable {
+    address private immutable ___self = address(this);
+
+    /**
+     * @notice verifies that the execution is called through an minimal proxy or is not a delegate call.
+     */
+    modifier notDelegatedOrIsMinimalProxy() {
+        if (address(this) != ___self) { 
+            address aquifer = aquifer();
+            address wellImplmentation = IAquifer(aquifer).wellImplementation(address(this));
+            require(wellImplmentation == ___self, "Function must be called by a Well bored by an aquifer");
+        } else {
+            revert("UUPSUpgradeable: must not be called through delegatecall");
+        }
+        _;
+    }
+
+    function init(
+        string memory _name,
+        string memory _symbol
+    ) external override reinitializer(2) {
+        // owner of Well param as the aquifier address will be the owner initially
+        // ownable init transfers ownership to msg.sender
+        __ERC20Permit_init(_name);
+        __ERC20_init(_name, _symbol);
+        __ReentrancyGuard_init();
+        __UUPSUpgradeable_init();
+        __Ownable_init();
+
+        IERC20[] memory _tokens = tokens();
+        uint256 tokensLength = _tokens.length;
+        for (uint256 i; i < tokensLength - 1; ++i) {
+            for (uint256 j = i + 1; j < tokensLength; ++j) {
+                if (_tokens[i] == _tokens[j]) {
+                    revert DuplicateTokens(_tokens[i]);
+                }
+            }
+        }
+    }
+
+    /**
+     * @notice `initClone` allows for the Well to be initialized without deploying a Well token.
+     * @dev This function is required given intializing with the Well token would create two valid Wells.
+     * Sets ReentraryGuard to true to prevent users from interacting with the Well.
+     */
+    function initNoWellToken() external initializer {}
+
+    // Wells deployed by aquifers use the EIP-1167 minimal proxy pattern for gas-efficent deployments.
+    // This pattern breaks the UUPS upgrade pattern, as the `__self` variable is set to the initial well implmentation.
+    // `_authorizeUpgrade` and `upgradeTo` are modified to allow for upgrades to the Well implementation.
+    // verification is done by verifying the ERC1967 implmentation (the well address) maps to the aquifers well -> implmentation mapping.
+
+    /**
+     * @notice Check that the execution is being performed through a delegatecall call and that the execution context is
+     * a proxy contract with an ERC1167 minimal proxy from an aquifier, pointing to a well implmentation.
+     */
+    function _authorizeUpgrade(address newImplmentation) internal view override {
+        // verify the function is called through a delegatecall.
+        require(address(this) != ___self, "Function must be called through delegatecall");
+
+        // verify the function is called through an active proxy bored by an aquifer.
+        address aquifer = aquifer();
+        address activeProxy = IAquifer(aquifer).wellImplementation(_getImplementation());
+        require(activeProxy == ___self, "Function must be called through active proxy bored by an aquifer");
+
+        // verify the new implmentation is a well bored by an aquifier.
+        require(
+            IAquifer(aquifer).wellImplementation(newImplmentation) !=
+                address(0),
+            "New implementation must be a well implmentation"
+        );
+
+        // verify the new implmentation is a valid ERC-1967 implmentation.
+        console.log("here");
+        require(
+            UUPSUpgradeable(newImplmentation).proxiableUUID() ==
+                _IMPLEMENTATION_SLOT,
+            "New implementation must be a valid ERC-1967 implmentation"
+        );
+    }
+
+    /**
+     * @notice Upgrades the implementation of the proxy to `newImplementation`.
+     * Calls {_authorizeUpgrade}.
+     * @dev `upgradeTo` was modified to support ERC-1167 minimal proxies 
+     * cloned (Bored) by an Aquifer.
+     */
+    function upgradeTo(address newImplementation) public override {
+        _authorizeUpgrade(newImplementation);
+        _upgradeToAndCallUUPS(newImplementation, new bytes(0), false);
+    }
+
+    /**
+     * @notice Upgrades the implementation of the proxy to `newImplementation`.
+     * Calls {_authorizeUpgrade}.
+     * @dev `upgradeTo` was modified to support ERC-1167 minimal proxies 
+     * cloned (Bored) by an Aquifer.
+     */
+    function upgradeToAndCall(address newImplementation, bytes memory data) public payable override  {
+        _authorizeUpgrade(newImplementation);
+        _upgradeToAndCallUUPS(newImplementation, data, true);
+    }
+
+    /**
+     * @dev Implementation of the ERC1822 {proxiableUUID} function. This returns the storage slot used by the
+     * implementation. It is used to validate the implementation's compatibility when performing an upgrade.
+     *
+     * IMPORTANT: A proxy pointing at a proxiable contract should not be considered proxiable itself, because this risks
+     * bricking a proxy that upgrades to it, by delegating to itself until out of gas. However, Wells bored by Aquifers
+     * are ERC-1167 minimal immutable clones and cannot delgate to another proxy. Thus, `proxiableUUID` was updated to support 
+     * this specific usecase.
+     */
+    function proxiableUUID() external view override notDelegatedOrIsMinimalProxy returns (bytes32) {
+        return _IMPLEMENTATION_SLOT;
+    }
+
+    function getImplementation() external view returns (address) {
+        return _getImplementation();
+    }
+
+     function getVersion() external pure virtual returns (uint256) {
+        return 1;
+    }
+
+    function getInitializerVersion() external view returns (uint256) {
+        return _getInitializedVersion();
+    }
+}

--- a/src/WellUpgradeable.sol
+++ b/src/WellUpgradeable.sol
@@ -106,7 +106,6 @@ contract WellUpgradeable is Well, UUPSUpgradeable, OwnableUpgradeable {
         );
 
         // verify the new implmentation is a valid ERC-1967 implmentation.
-        console.log("here");
         require(
             UUPSUpgradeable(newImplmentation).proxiableUUID() ==
                 _IMPLEMENTATION_SLOT,

--- a/src/libraries/LibWellUpgradeableConstructor.sol
+++ b/src/libraries/LibWellUpgradeableConstructor.sol
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: MIT
+// forgefmt: disable-start
+
+pragma solidity ^0.8.20;
+
+import {LibContractInfo} from "src/libraries/LibContractInfo.sol";
+import {Call, IERC20} from "src/Well.sol";
+import {WellUpgradeable} from "src/WellUpgradeable.sol";
+
+library LibWellUpgradeableConstructor {
+
+    /**
+     * @notice Encode the Well's immutable data.
+     */
+    function encodeWellDeploymentData(
+        address _aquifer,
+        IERC20[] memory _tokens,
+        Call memory _wellFunction,
+        Call[] memory _pumps
+    ) internal pure returns (bytes memory immutableData, bytes memory initData) {
+        immutableData = encodeWellImmutableData(_aquifer, _tokens, _wellFunction, _pumps);
+        initData = abi.encodeWithSelector(WellUpgradeable.initNoWellToken.selector);
+    }
+
+    /**
+     * @notice Encode the Well's immutable data.
+     * @param _aquifer The address of the Aquifer which will deploy this Well.
+     * @param _tokens A list of ERC20 tokens supported by the Well.
+     * @param _wellFunction A single Call struct representing a call to the Well Function.
+     * @param _pumps An array of Call structs representings calls to Pumps.
+     * @dev `immutableData` is tightly packed, however since `_tokens` itself is
+     * an array, each address in the array will be padded up to 32 bytes.
+     *
+     * Arbitrary-length bytes are applied to the end of the encoded bytes array
+     * for easy reading of statically-sized data.
+     * 
+     */
+    function encodeWellImmutableData(
+        address _aquifer,
+        IERC20[] memory _tokens,
+        Call memory _wellFunction,
+        Call[] memory _pumps
+    ) internal pure returns (bytes memory immutableData) {
+        
+        immutableData = abi.encodePacked(
+            _aquifer,                   // aquifer address
+            _tokens.length,             // number of tokens
+            _wellFunction.target,       // well function address
+            _wellFunction.data.length,  // well function data length
+            _pumps.length,              // number of pumps
+            _tokens,                    // tokens array
+            _wellFunction.data         // well function data (bytes)
+        );
+        for (uint256 i; i < _pumps.length; ++i) {
+            immutableData = abi.encodePacked(
+                immutableData,            // previously packed pumps
+                _pumps[i].target,       // pump address
+                _pumps[i].data.length,  // pump data length
+                _pumps[i].data          // pump data (bytes)
+            );
+        }
+    }
+
+    function encodeWellInitFunctionCall(
+        IERC20[] memory _tokens,
+        Call memory _wellFunction
+    ) public view returns (bytes memory initFunctionCall) {
+        string memory name = LibContractInfo.getSymbol(address(_tokens[0]));
+        string memory symbol = name;
+        for (uint256 i = 1; i < _tokens.length; ++i) {
+            name = string.concat(name, ":", LibContractInfo.getSymbol(address(_tokens[i])));
+            symbol = string.concat(symbol, LibContractInfo.getSymbol(address(_tokens[i])));
+        }
+        name = string.concat(name, " ", LibContractInfo.getName(_wellFunction.target), " Upgradeable Well");
+        symbol = string.concat(symbol, LibContractInfo.getSymbol(_wellFunction.target), "uw");
+
+        // See {Well.init}.
+        initFunctionCall = abi.encodeWithSelector(WellUpgradeable.init.selector, name, symbol);
+    }
+
+    /**
+     * @notice Encode a Call struct representing an arbitrary call to `target` with additional data `data`.
+     */
+    function encodeCall(address target, bytes memory data) public pure returns (Call memory) {
+        return Call(target, data);
+    }
+}

--- a/src/pumps/MultiFlowPump.sol
+++ b/src/pumps/MultiFlowPump.sol
@@ -272,7 +272,7 @@ contract MultiFlowPump is IPump, IMultiFlowPumpErrors, IInstantaneousPump, ICumu
             crv.rLimit = tempExp.cmp(MAX_CONVERT_TO_128x128) != -1
                 ? crv.rLimit = type(uint256).max
                 : crv.rLast.mulDivOrMax(tempExp.to128x128().toUint256(), CAP_PRECISION2);
-            if (cappedReserves[i].mulDiv(CAP_PRECISION, cappedReserves[j]) > crv.rLimit) {
+            if (crv.r > crv.rLimit) {
                 calcReservesAtRatioSwap(mfpWf, crv.rLimit, cappedReserves, i, j, data);
             }
             // If the ratio decreased, check that it didn't decrease below the max.
@@ -282,7 +282,7 @@ contract MultiFlowPump is IPump, IMultiFlowPumpErrors, IInstantaneousPump, ICumu
                     .toUint256(),
                 CAP_PRECISION2
             );
-            if (cappedReserves[i].mulDiv(CAP_PRECISION, cappedReserves[j]) < crv.rLimit) {
+            if (crv.r < crv.rLimit) {
                 calcReservesAtRatioSwap(mfpWf, crv.rLimit, cappedReserves, i, j, data);
             }
         }

--- a/src/pumps/MultiFlowPump.sol
+++ b/src/pumps/MultiFlowPump.sol
@@ -512,7 +512,7 @@ contract MultiFlowPump is IPump, IMultiFlowPumpErrors, IInstantaneousPump, ICumu
      * @dev Get the slot number that contains the `n`th element of an array.
      */
     function _getSlotsOffset(uint256 numberOfReserves) internal pure returns (uint256 _slotsOffset) {
-        _slotsOffset = ((numberOfReserves - 1) / 2 + 1);
+        _slotsOffset = ((numberOfReserves - 1) / 2 + 1) << 5;
     }
 
     /**

--- a/src/pumps/MultiFlowPump.sol
+++ b/src/pumps/MultiFlowPump.sol
@@ -14,7 +14,6 @@ import {LibLastReserveBytes} from "src/libraries/LibLastReserveBytes.sol";
 import {Math} from "oz/utils/math/Math.sol";
 import {SafeCast} from "oz/utils/math/SafeCast.sol";
 import {LibMath} from "src/libraries/LibMath.sol";
-import {console} from "test/TestHelper.sol";
 
 /**
  * @title MultiFlowPump
@@ -282,10 +281,7 @@ contract MultiFlowPump is IPump, IMultiFlowPumpErrors, IInstantaneousPump, ICumu
             // Check for overflow before converting to 128x128
             if (tempExp.cmp(MAX_CONVERT_TO_128x128) != -1) {
                 crv.rLimit = 0; // Set limit to 0 in case of overflow
-                console.log("overflow happened, so setting to zero");
-                revert("overflow");
             } else {
-                console.log("there was no overflow");
                 crv.rLimit = crv.rLast.mulDiv(tempExp.to128x128().toUint256(), CAP_PRECISION2);
             }
             if (crv.r < crv.rLimit) {

--- a/src/pumps/MultiFlowPump.sol
+++ b/src/pumps/MultiFlowPump.sol
@@ -71,6 +71,11 @@ contract MultiFlowPump is IPump, IMultiFlowPumpErrors, IInstantaneousPump, ICumu
      * @dev Update the Pump's manipulation resistant reserve balances for a given `well` with `reserves`.
      */
     function update(uint256[] calldata reserves, bytes calldata data) external {
+        // Require two token well
+        if (reserves.length != 2) {
+            revert TooManyTokens();
+        }
+
         (bytes16 alpha, uint256 capInterval, CapReservesParameters memory crp) =
             abi.decode(data, (bytes16, uint256, CapReservesParameters));
         uint256 numberOfReserves = reserves.length;
@@ -227,11 +232,6 @@ contract MultiFlowPump is IPump, IMultiFlowPumpErrors, IInstantaneousPump, ICumu
         uint256 capExponent,
         CapReservesParameters memory crp
     ) internal view returns (uint256[] memory cappedReserves) {
-        // Assume two token well
-        if (reserves.length != 2) {
-            revert TooManyTokens();
-        }
-
         Call memory wf = IWell(well).wellFunction();
         IMultiFlowPumpWellFunction mfpWf = IMultiFlowPumpWellFunction(wf.target);
 

--- a/src/pumps/MultiFlowPump.sol
+++ b/src/pumps/MultiFlowPump.sol
@@ -513,10 +513,10 @@ contract MultiFlowPump is IPump, IMultiFlowPumpErrors, IInstantaneousPump, ICumu
     }
 
     /**
-     * @dev Get the starting byte of the slot that contains the `n`th element of an array.
+     * @dev Get the slot number that contains the `n`th element of an array.
      */
     function _getSlotsOffset(uint256 numberOfReserves) internal pure returns (uint256 _slotsOffset) {
-        _slotsOffset = ((numberOfReserves - 1) / 2 + 1) << 5;
+        _slotsOffset = ((numberOfReserves - 1) / 2 + 1);
     }
 
     /**

--- a/test/TestHelper.sol
+++ b/test/TestHelper.sol
@@ -326,7 +326,6 @@ abstract contract TestHelper is Test, WellDeployer {
         uint256 numDigitsA = numDigits(a);
         uint256 numDigitsB = numDigits(b);
         if (numDigitsA != numDigitsB || numDigitsA < precision) {
-            console.log("Here for some reason");
             if (b > absoluteError) {
                 assertGe(a, b - absoluteError);
             }

--- a/test/WellUpgradeable.t.sol
+++ b/test/WellUpgradeable.t.sol
@@ -1,0 +1,243 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.20;
+
+import {Test, console} from "forge-std/Test.sol";
+import {WellUpgradeable} from "src/WellUpgradeable.sol";
+import {IERC20} from "test/TestHelper.sol";
+import {WellDeployer} from "script/helpers/WellDeployer.sol";
+import {MockPump} from "mocks/pumps/MockPump.sol";
+import {Well, Call, IWellFunction, IPump, IERC20} from "src/Well.sol";
+import {ConstantProduct2} from "src/functions/ConstantProduct2.sol";
+import {Aquifer} from "src/Aquifer.sol";
+import {WellDeployer} from "script/helpers/WellDeployer.sol";
+import {LibWellUpgradeableConstructor} from "src/libraries/LibWellUpgradeableConstructor.sol";
+import {LibContractInfo} from "src/libraries/LibContractInfo.sol";
+import {MockToken} from "mocks/tokens/MockToken.sol";
+import {WellDeployer} from "script/helpers/WellDeployer.sol";
+import {ERC1967Proxy} from "oz/proxy/ERC1967/ERC1967Proxy.sol";
+import {MockWellUpgradeable} from "mocks/wells/MockWellUpgradeable.sol";
+
+contract WellUpgradeTest is Test, WellDeployer {
+    address proxyAddress;
+    address aquifer;
+    address initialOwner;
+    address user;
+    address mockPumpAddress;
+    address wellFunctionAddress;
+    address token1Address;
+    address token2Address;
+    address wellAddress;
+    address wellImplementation;
+
+    function setUp() public {
+        // Tokens
+        IERC20[] memory tokens = new IERC20[](2);
+        tokens[0] = new MockToken("BEAN", "BEAN", 6);
+        tokens[1] = new MockToken("WETH", "WETH", 18);
+
+        token1Address = address(tokens[0]);
+        vm.label(token1Address, "token1");
+        token2Address = address(tokens[1]);
+        vm.label(token2Address, "token2");
+
+        user = makeAddr("user");
+
+        // Mint tokens
+        MockToken(address(tokens[0])).mint(user, 10000000000000000);
+        MockToken(address(tokens[1])).mint(user, 10000000000000000);
+        // Well Function
+        IWellFunction cp2 = new ConstantProduct2();
+        vm.label(address(cp2), "CP2");
+        wellFunctionAddress = address(cp2);
+        Call memory wellFunction = Call(
+            address(cp2),
+            abi.encode("beanstalkFunction")
+        );
+
+        // Pump
+        IPump mockPump = new MockPump();
+        mockPumpAddress = address(mockPump);
+        vm.label(mockPumpAddress, "mockPump");
+        Call[] memory pumps = new Call[](1);
+        // init new mock pump with "beanstalk" data
+        pumps[0] = Call(address(mockPump), abi.encode("beanstalkPump"));
+        aquifer = address(new Aquifer());
+        vm.label(aquifer, "aquifer");
+        wellImplementation = address(new WellUpgradeable());
+        vm.label(wellImplementation, "wellImplementation");
+        initialOwner = makeAddr("owner");
+
+        // Well
+        WellUpgradeable well = encodeAndBoreWellUpgradeable(
+            aquifer,
+            wellImplementation,
+            tokens,
+            wellFunction,
+            pumps,
+            bytes32(0)
+        );
+        wellAddress = address(well);
+        vm.label(wellAddress, "upgradeableWell");
+        // Sum up of what is going on here
+        // We encode and bore a well upgradeable from the aquifer
+        // The well upgradeable additionally takes in an owner address so we modify the init function call
+        // to include the owner address.
+        // When the new well is deployed, all init data are stored in the implementation storage
+        // including pump and well function data --> NOTE: This could be an issue but how do we solve this?
+        // Then we deploy a ERC1967Proxy proxy for the well upgradeable and call the init function on the proxy
+        // When we deploy the proxy, the init data is stored in the proxy storage and the well is initialized
+        // for the second time. We can now control the well via delegate calls to the proxy address.
+
+        // Every time we call the init function, we init the owner to be the msg.sender and
+        // then immidiately transfer ownership
+        // to an address of our choice (see WellUpgradeable.sol for more details on the init function)
+
+        // FROM OZ
+        // If _data is nonempty, it’s used as data in a delegate call to _logic.
+        // This will typically be an encoded function call, and allows initializing
+        // the storage of the proxy like a Solidity constructor.
+
+        // Deploy Proxy
+        vm.startPrank(initialOwner);
+        ERC1967Proxy proxy = new ERC1967Proxy(
+            address(well), // implementation address
+            LibWellUpgradeableConstructor.encodeWellInitFunctionCall(
+                tokens,
+                wellFunction
+            )  // init data
+        );
+        vm.stopPrank();
+        proxyAddress = address(proxy);
+        vm.label(proxyAddress, "proxyAddress");
+
+        vm.startPrank(user);
+        tokens[0].approve(wellAddress, type(uint256).max);
+        tokens[1].approve(wellAddress, type(uint256).max);
+        tokens[0].approve(proxyAddress, type(uint256).max);
+        tokens[1].approve(proxyAddress, type(uint256).max);
+        vm.stopPrank();
+    }
+
+    ///////////////////// Storage Tests /////////////////////
+
+    function testProxyGetAquifer() public {
+        assertEq(address(aquifer), WellUpgradeable(proxyAddress).aquifer());
+    }
+
+    function testProxyGetPump() public {
+        Call[] memory proxyPumps = WellUpgradeable(proxyAddress).pumps();
+        assertEq(mockPumpAddress, proxyPumps[0].target);
+        // this passes but why? Pump data are supposed
+        // to be stored in the implementation storage from the borewell call
+        assertEq(abi.encode("beanstalkPump"), proxyPumps[0].data);
+    }
+
+    function testProxyGetTokens() public {
+        IERC20[] memory proxyTokens = WellUpgradeable(proxyAddress).tokens();
+        assertEq(address(proxyTokens[0]), token1Address);
+        assertEq(address(proxyTokens[1]), token2Address);
+    }
+
+    function testProxyGetWellFunction() public {
+        Call memory proxyWellFunction = WellUpgradeable(proxyAddress)
+            .wellFunction();
+        assertEq(
+            address(proxyWellFunction.target),
+            address(wellFunctionAddress)
+        );
+        assertEq(proxyWellFunction.data, abi.encode("beanstalkFunction"));
+    }
+
+    function testProxyGetSymbolInStorage() public {
+        assertEq("BEANWETHCP2uw", WellUpgradeable(proxyAddress).symbol());
+    }
+
+    function testProxyInitVersion() public {
+        uint256 expectedVersion = 1;
+        assertEq(expectedVersion, WellUpgradeable(proxyAddress).getVersion());
+    }
+
+    function testProxyNumTokens() public {
+        uint256 expectedNumTokens = 2;
+        assertEq(
+            expectedNumTokens,
+            WellUpgradeable(proxyAddress).numberOfTokens()
+        );
+    }
+
+    ///////////////// Interaction test //////////////////
+
+    function testProxyAddLiquidity() public {
+        vm.startPrank(user);
+        uint256[] memory amounts = new uint256[](2);
+        amounts[0] = 1000;
+        amounts[1] = 1000;
+        WellUpgradeable(wellAddress).addLiquidity(
+            amounts,
+            0,
+            user,
+            type(uint256).max
+        );
+        WellUpgradeable(proxyAddress).addLiquidity(
+            amounts,
+            0,
+            user,
+            type(uint256).max
+        );
+        assertEq(amounts, WellUpgradeable(proxyAddress).getReserves());
+        vm.stopPrank();
+    }
+
+    ////////////// Ownership Tests //////////////
+
+    function testProxyOwner() public {
+        assertEq(initialOwner, WellUpgradeable(proxyAddress).owner());
+    }
+
+    function testProxyTransferOwnership() public {
+        vm.prank(initialOwner);
+        address newOwner = makeAddr("newOwner");
+        WellUpgradeable(proxyAddress).transferOwnership(newOwner);
+        assertEq(newOwner, WellUpgradeable(proxyAddress).owner());
+    }
+
+    function testRevertTransferOwnershipFromNotOnwer() public {
+        vm.expectRevert();
+        address notOwner = makeAddr("notOwner");
+        vm.prank(notOwner);
+        WellUpgradeable(proxyAddress).transferOwnership(notOwner);
+    }
+
+    ////////////////////// Upgrade Tests //////////////////////
+
+    function testUpgradeToNewImplementation() public {
+        IERC20[] memory tokens = new IERC20[](2);
+        tokens[0] = new MockToken("BEAN", "BEAN", 6);
+        tokens[1] = new MockToken("WETH", "WETH", 18);
+        Call memory wellFunction = Call(wellFunctionAddress, abi.encode("2"));
+        Call[] memory pumps = new Call[](1);
+        pumps[0] = Call(mockPumpAddress, abi.encode("2"));
+        // create new mock Well Implementation: 
+        address wellImpl = address(new MockWellUpgradeable());
+        WellUpgradeable well2 = encodeAndBoreWellUpgradeable(
+            aquifer,
+            wellImpl,
+            tokens,
+            wellFunction,
+            pumps,
+            bytes32(abi.encode("2"))
+        );
+        vm.label(address(well2), "upgradeableWell2");
+
+        vm.startPrank(initialOwner);
+        WellUpgradeable proxy = WellUpgradeable(payable(proxyAddress));
+        proxy.upgradeTo(address(well2));
+        assertEq(initialOwner, MockWellUpgradeable(proxyAddress).owner());
+        // verify proxy was upgraded.
+        assertEq(address(well2), MockWellUpgradeable(proxyAddress).getImplementation());
+        assertEq(1, MockWellUpgradeable(proxyAddress).getVersion());
+        assertEq(100, MockWellUpgradeable(proxyAddress).getVersion(100));
+        vm.stopPrank();
+    }
+}

--- a/test/WellUpgradeable.t.sol
+++ b/test/WellUpgradeable.t.sol
@@ -83,8 +83,6 @@ contract WellUpgradeTest is Test, WellDeployer {
         // We encode and bore a well upgradeable from the aquifer
         // The well upgradeable additionally takes in an owner address so we modify the init function call
         // to include the owner address.
-        // When the new well is deployed, all init data are stored in the implementation storage
-        // including pump and well function data --> NOTE: This could be an issue but how do we solve this?
         // Then we deploy a ERC1967Proxy proxy for the well upgradeable and call the init function on the proxy
         // When we deploy the proxy, the init data is stored in the proxy storage and the well is initialized
         // for the second time. We can now control the well via delegate calls to the proxy address.

--- a/test/pumps/Pump.Fuzz.t.sol
+++ b/test/pumps/Pump.Fuzz.t.sol
@@ -59,7 +59,7 @@ contract PumpFuzzTest is TestHelper, MultiFlowPump {
             reserves[i] = bound(reserves[i], 1e6, 1e32);
         }
 
-        timeIncrease = 1099511627775; //1099511627775 is max uint40
+        // timeIncrease = 1099511627775; //1099511627775 is max uint40
 
         vm.assume(block.timestamp + timeIncrease <= type(uint40).max);
 

--- a/test/pumps/Pump.Fuzz.t.sol
+++ b/test/pumps/Pump.Fuzz.t.sol
@@ -58,6 +58,9 @@ contract PumpFuzzTest is TestHelper, MultiFlowPump {
             initReserves[i] = bound(initReserves[i], 1e6, 1e32);
             reserves[i] = bound(reserves[i], 1e6, 1e32);
         }
+
+        timeIncrease = 1099511627775; //1099511627775 is max uint40
+
         vm.assume(block.timestamp + timeIncrease <= type(uint40).max);
 
         // Start by updating the Pump with the initial reserves. Also initializes the Pump.
@@ -119,5 +122,8 @@ contract PumpFuzzTest is TestHelper, MultiFlowPump {
                 }
             }
         }
+        // assertTrue(false);
     }
+
+
 }

--- a/test/pumps/Pump.Helpers.t.sol
+++ b/test/pumps/Pump.Helpers.t.sol
@@ -8,7 +8,7 @@ import {console, TestHelper} from "test/TestHelper.sol";
 
 contract PumpHelpersTest is TestHelper, MultiFlowPump {
     uint256[5] testCasesInput = [1, 2, 3, 4, 5];
-    uint256[5] testCasesOutput = [32, 32, 64, 64, 96];
+    uint256[5] testCasesOutput = [1, 1, 2, 2, 3];
 
     constructor() MultiFlowPump() {}
 

--- a/test/pumps/Pump.Helpers.t.sol
+++ b/test/pumps/Pump.Helpers.t.sol
@@ -8,7 +8,7 @@ import {console, TestHelper} from "test/TestHelper.sol";
 
 contract PumpHelpersTest is TestHelper, MultiFlowPump {
     uint256[5] testCasesInput = [1, 2, 3, 4, 5];
-    uint256[5] testCasesOutput = [1, 1, 2, 2, 3];
+    uint256[5] testCasesOutput = [32, 32, 64, 64, 96];
 
     constructor() MultiFlowPump() {}
 


### PR DESCRIPTION
# MultiFlow Pump v1.1 Codehawks Remediations

Audit results: https://www.codehawks.com/report/clv1eptuo0003bcnzce1ap7om

## Codehawks Remediations

### M-01. Ignoring the Well Function logic for a ratio of reserves calculation

Original finding: https://www.codehawks.com/report/clv1eptuo0003bcnzce1ap7om#M-01

Remediation: Use `crv.r` in place of `cappedReserves[i].mulDiv(CAP_PRECISION, cappedReserves[j])` as suggested by the auditor. 43d3e24d9a542c21605ceaa8f534c1c39593ebf0

### L-01. Missing overflow protection in `_capRates` function can lead to broken wells and pumps after a few blocks of unuse

Original finding: https://www.codehawks.com/report/clv1eptuo0003bcnzce1ap7om#L-01

Remediation: Added overflow check as recommended. 001a8c105c6c5ec7a82c2431925301457b89dfb7

Note: there is no test to verify this check works as expected.

### L-02. Absence of reserves length check during pump initialization can lead to storage corruption.

Original finding: https://www.codehawks.com/report/clv1eptuo0003bcnzce1ap7om#L-02

Remediation: Move reserves length check as recommended. ee877343635f3a22a1de7d8b2b9a6b52aa82beed

# Accepted Risks from Codehawks Findings

### L-03. Using bytes number instead of slots number in the next slot calculation

Original finding: https://www.codehawks.com/report/clv1eptuo0003bcnzce1ap7om#L-03

L-03 makes sense only if data is stored in one slot per well. With 2 reserves, this can be done as the values of the reserves are packed in one slot (each reserve is stored as a uint128). However, with 3 or more reserves, there would not be slots available. By keeping data 32 slots apart, plenty of room is available for more complex use cases.

# Other contract changes

## Upgradable Wells

This PR introduces an upgradeable well implementation.

The flow of calls works in this sequence:
1. ERC-1967 proxy
2. ERC-1167 minimal clone well proxy
3. Actual Well implementation

Upgradable wells use the UUPS (Universal Upgradeable Proxy Standard) pattern, upgradability can be removed in the future so that contracts become static.

UUPS also implements some safeguards ensuring the new implementation contract is upgrade safe. It was necessary to override some of them in order to accommodate the "chain of proxies" design that comes with how the well is created and avoids reverts. Specifically, `authorizeUpgrade` https://github.com/BeanstalkFarms/Basin/blob/dd66d36cd70679b8b394ec76a25845a678c612da/src/WellUpgradeable.sol#L92 is overridden with custom proxy checks and Well validation. Also `proxiableUUID()` is reverted to allow being called by a proxy.