### PR TITLE
CalcReserve extreme values fix [#25] [#22]

### DIFF
--- a/test/TestHelper.sol
+++ b/test/TestHelper.sol
@@ -13,7 +13,6 @@ import {Users} from "test/helpers/Users.sol";
 import {Well, Call, IERC20, IWell, IWellFunction} from "src/Well.sol";
 import {Aquifer} from "src/Aquifer.sol";
 import {ConstantProduct2} from "src/functions/ConstantProduct2.sol";
-import {ConstantProduct} from "src/functions/ConstantProduct.sol";
 import {Stable2} from "src/functions/Stable2.sol";
 import {Stable2LUT1} from "src/functions/StableLUT/Stable2LUT1.sol";
 
@@ -74,13 +73,6 @@ abstract contract TestHelper is Test, WellDeployer {
 
     function setupWell(uint256 n) internal {
         setupWell(n, deployWellFunction(), deployPumps(1));
-    }
-
-    function setup3Well() internal {
-        Call memory _wellFunction;
-        _wellFunction.target = address(new ConstantProduct());
-        _wellFunction.data = new bytes(0);
-        setupWell(3, deployWellFunction(), deployPumps(1));
     }
 
     function setupWell(uint256 n, Call[] memory _pumps) internal {

--- a/test/TestHelper.sol
+++ b/test/TestHelper.sol
@@ -13,6 +13,7 @@ import {Users} from "test/helpers/Users.sol";
 import {Well, Call, IERC20, IWell, IWellFunction} from "src/Well.sol";
 import {Aquifer} from "src/Aquifer.sol";
 import {ConstantProduct2} from "src/functions/ConstantProduct2.sol";
+import {ConstantProduct} from "src/functions/ConstantProduct.sol";
 import {Stable2} from "src/functions/Stable2.sol";
 import {Stable2LUT1} from "src/functions/StableLUT/Stable2LUT1.sol";
 
@@ -73,6 +74,13 @@ abstract contract TestHelper is Test, WellDeployer {
 
     function setupWell(uint256 n) internal {
         setupWell(n, deployWellFunction(), deployPumps(1));
+    }
+
+    function setup3Well() internal {
+        Call memory _wellFunction;
+        _wellFunction.target = address(new ConstantProduct());
+        _wellFunction.data = new bytes(0);
+        setupWell(3, deployWellFunction(), deployPumps(1));
     }
 
     function setupWell(uint256 n, Call[] memory _pumps) internal {

--- a/test/beanstalk/BeanstalkStable2.calcReserveAtRatioLiquidity.t.sol
+++ b/test/beanstalk/BeanstalkStable2.calcReserveAtRatioLiquidity.t.sol
@@ -111,7 +111,7 @@ contract BeanstalkStable2LiquidityTest is TestHelper {
             // estimated price and actual price are within 0.04% in the worst case.
             assertApproxEqRel(reservePrice0, targetPrice, 0.0004e18, "reservePrice0 <> targetPrice");
             assertApproxEqRel(reservePrice1, targetPrice, 0.0004e18, "reservePrice1 <> targetPrice");
-            assertApproxEqRel(reservePrice0, reservePrice1, 0.0004e18, "reservePrice0 <> reservePrice1");
+            assertApproxEqRel(reservePrice0, reservePrice1, 0.0005e18, "reservePrice0 <> reservePrice1");
         }
     }
 
@@ -120,5 +120,21 @@ contract BeanstalkStable2LiquidityTest is TestHelper {
         uint256[] memory ratios = new uint256[](2);
         vm.expectRevert();
         _f.calcReserveAtRatioLiquidity(reserves, 2, ratios, "");
+    }
+
+    function test_calcReserveAtRatioLiquidityExtreme() public view {
+        uint256[] memory reserves = new uint256[](2);
+        reserves[0] = 1e18;
+        reserves[1] = 1e18;
+        uint256[] memory ratios = new uint256[](2);
+        ratios[0] = 8;
+        ratios[1] = 1;
+
+        uint256 reserve0 = _f.calcReserveAtRatioLiquidity(reserves, 0, ratios, data);
+
+        reserves[0] = reserve0;
+
+        uint256 price = _f.calcRate(reserves, 1, 0, data);
+        assertApproxEqRel(price, 125_000, 0.01e18);
     }
 }

--- a/test/beanstalk/BeanstalkStable2.calcReserveAtRatioSwap.t.sol
+++ b/test/beanstalk/BeanstalkStable2.calcReserveAtRatioSwap.t.sol
@@ -60,8 +60,8 @@ contract BeanstalkStable2SwapTest is TestHelper {
         uint256 reserve0 = _f.calcReserveAtRatioSwap(reserves, 0, ratios, data);
         uint256 reserve1 = _f.calcReserveAtRatioSwap(reserves, 1, ratios, data);
 
-        assertEq(reserve0, 180.643950056605911775e18); // 180.64235400499155996e18, 100e18
-        assertEq(reserve1, 39.474875366590812867e18); // 100e18, 39.474875366590812867e18
+        assertEq(reserve0, 180.644064978044534737e18); // 180.644064978044534737e18, 100e18
+        assertEq(reserve1, 39.475055811844664131e18); // 100e18, 39.475055811844664131e18
     }
 
     function test_calcReserveAtRatioSwap_diff_diff() public view {
@@ -100,5 +100,27 @@ contract BeanstalkStable2SwapTest is TestHelper {
             // estimated price and actual price are within 0.015% in the worst case.
             assertApproxEqRel(reservePrice0, targetPrice, 0.00015e18, "reservePrice0 <> targetPrice");
         }
+    }
+
+    /**
+     * @notice verifies calcReserveAtRatioSwapExtreme works in the extreme ranges.
+     */
+    function test_calcReserveAtRatioSwapExtreme() public view {
+        uint256[] memory reserves = new uint256[](2);
+        reserves[0] = 1e18;
+        reserves[1] = 1e18;
+        uint256[] memory ratios = new uint256[](2);
+        ratios[0] = 4202;
+        ratios[1] = 19_811;
+        uint256 targetPrice = uint256(ratios[0] * 1e6 / ratios[1]);
+
+        uint256 reserve0 = _f.calcReserveAtRatioSwap(reserves, 0, ratios, data);
+        uint256 reserve1 = _f.calcReserveAtRatioSwap(reserves, 1, ratios, data);
+
+        reserves[0] = reserve0;
+        reserves[1] = reserve1;
+
+        uint256 price = _f.calcRate(reserves, 0, 1, data);
+        assertApproxEqAbs(price, targetPrice, 1);
     }
 }


### PR DESCRIPTION
`calcReserveAtRatioSwap` and `calcReserveAtRatioLiquidity` utilize a LUT to decrease the computation needed to estimate the reserves. When this function is called at extremely high or low values, the function can revert due to overflow or the function not converging. 

This PR implements the following: 
- readjusts the max step size when `scaledReserve[j]` is updated. This ensures that maxStep size can never be larger than the `j` reserve. 
 
- In the case where newton's method overestimates, set high/low price to the new price, which guarantees convergence. 

This PR resolves [#25](https://github.com/code-423n4/2024-07-basin-findings/issues/25) and [#22](https://github.com/code-423n4/2024-07-basin-findings/issues/22).