### PR TITLE
S2 upgr well remediations 2

### DIFF
--- a/src/functions/Stable2.sol
+++ b/src/functions/Stable2.sol
@@ -42,7 +42,7 @@ contract Stable2 is ProportionalLPToken2, IBeanstalkWellFunction {
 
     // price threshold. more accurate pricing requires a lower threshold,
     // at the cost of higher execution costs.
-    uint256 constant PRICE_THRESHOLD = 100; // 0.01%
+    uint256 constant PRICE_THRESHOLD = 10; // 0.001%
 
     address immutable lookupTable;
     uint256 immutable a;
@@ -213,7 +213,7 @@ contract Stable2 is ProportionalLPToken2, IBeanstalkWellFunction {
         uint256 parityReserve = lpTokenSupply / 2;
 
         // update `scaledReserves` based on whether targetPrice is closer to low or high price:
-        if (pd.lutData.highPrice - pd.targetPrice > pd.targetPrice - pd.lutData.lowPrice) {
+        if (percentDiff(pd.lutData.highPrice, pd.targetPrice) > percentDiff(pd.lutData.lowPrice, pd.targetPrice)) {
             // targetPrice is closer to lowPrice.
             scaledReserves[i] = parityReserve * pd.lutData.lowPriceI / pd.lutData.precision;
             scaledReserves[j] = parityReserve * pd.lutData.lowPriceJ / pd.lutData.precision;
@@ -297,7 +297,7 @@ contract Stable2 is ProportionalLPToken2, IBeanstalkWellFunction {
 
         // update scaledReserve[j] such that calcRate(scaledReserves, i, j) = low/high Price,
         // depending on which is closer to targetPrice.
-        if (pd.lutData.highPrice - pd.targetPrice > pd.targetPrice - pd.lutData.lowPrice) {
+        if (percentDiff(pd.lutData.highPrice, pd.targetPrice) > percentDiff(pd.lutData.lowPrice, pd.targetPrice)) {
             // targetPrice is closer to lowPrice.
             scaledReserves[j] = scaledReserves[i] * pd.lutData.lowPriceJ / pd.lutData.precision;
 
@@ -443,5 +443,20 @@ contract Stable2 is ProportionalLPToken2, IBeanstalkWellFunction {
             return reserve
                 + pd.maxStepSize * (pd.currentPrice - pd.targetPrice) / (pd.lutData.highPrice - pd.lutData.lowPrice);
         }
+    }
+
+    /**
+     * @notice Calculate the percentage difference between two numbers.
+     * @return The percentage difference as a fixed-point number with 18 decimals.
+     * @dev This function calculates the absolute percentage difference:
+     *      |(a - b)| / ((a + b) / 2) * 100
+     *      The result is scaled by 1e18 for precision.
+     */
+    function percentDiff(uint256 _a, uint256 _b) internal pure returns (uint256) {
+        if (_a == _b) return 0;
+        uint256 difference = _a > _b ? _a - _b : _b - _a;
+        uint256 average = (_a + _b) / 2;
+        // Multiply by 100 * 1e18 to get percentage with 18 decimal places
+        return (difference * 100 * 1e18) / average;
     }
 }

--- a/test/beanstalk/BeanstalkStable2.calcReserveAtRatioLiquidity.t.sol
+++ b/test/beanstalk/BeanstalkStable2.calcReserveAtRatioLiquidity.t.sol
@@ -61,7 +61,7 @@ contract BeanstalkStable2LiquidityTest is TestHelper {
         uint256 reserve0 = _f.calcReserveAtRatioLiquidity(reserves, 0, ratios, data);
         uint256 reserve1 = _f.calcReserveAtRatioLiquidity(reserves, 1, ratios, data);
 
-        assertApproxEqRel(reserve0, 4.575771214546676444e18, 0.0001e18);
+        assertApproxEqRel(reserve0, 4.576236561359714812e18, 0.0001e18);
         assertApproxEqRel(reserve1, 0.21852354514449462e18, 0.0001e18);
     }
 

--- a/test/beanstalk/BeanstalkStable2.calcReserveAtRatioSwap.t.sol
+++ b/test/beanstalk/BeanstalkStable2.calcReserveAtRatioSwap.t.sol
@@ -30,8 +30,8 @@ contract BeanstalkStable2SwapTest is TestHelper {
         uint256 reserve0 = _f.calcReserveAtRatioSwap(reserves, 0, ratios, data);
         uint256 reserve1 = _f.calcReserveAtRatioSwap(reserves, 1, ratios, data);
 
-        assertEq(reserve0, 100.005058322101089709e18);
-        assertEq(reserve1, 100.005058322101089709e18);
+        assertEq(reserve0, 99.999921040536083478e18);
+        assertEq(reserve1, 99.999921040536083478e18);
     }
 
     function test_calcReserveAtRatioSwap_equal_diff() public view {
@@ -45,8 +45,8 @@ contract BeanstalkStable2SwapTest is TestHelper {
         uint256 reserve0 = _f.calcReserveAtRatioSwap(reserves, 0, ratios, data);
         uint256 reserve1 = _f.calcReserveAtRatioSwap(reserves, 1, ratios, data);
 
-        assertEq(reserve0, 73.517644476151580971e18);
-        assertEq(reserve1, 73.517644476151580971e18);
+        assertEq(reserve0, 73.513867858788351572e18);
+        assertEq(reserve1, 73.513867858788351572e18);
     }
 
     function test_calcReserveAtRatioSwap_diff_equal() public view {
@@ -61,7 +61,7 @@ contract BeanstalkStable2SwapTest is TestHelper {
         uint256 reserve1 = _f.calcReserveAtRatioSwap(reserves, 1, ratios, data);
 
         assertEq(reserve0, 180.644064978044534737e18); // 180.644064978044534737e18, 100e18
-        assertEq(reserve1, 39.475055811844664131e18); // 100e18, 39.475055811844664131e18
+        assertEq(reserve1, 39.474244037189430513e18); // 100e18, 39.475055811844664131e18
     }
 
     function test_calcReserveAtRatioSwap_diff_diff() public view {


### PR DESCRIPTION
This PR addresses the findings found from the codeArena remediation audit. 

- decreased `PRICE_THRESHOLD` from 100 to 10, used in `calcReservesAtRatioSwap` and `calcReserveAtRatioLiquidity`. This significantly increases the accuracy of the reserve with a marginal increase in gas. 
- In extreme edge cases, `calcLpTokenSupply ` would not converge at extreme ratios, and would instead oscillate +/- 1 unit around the target value. An boolean check was added if this case occurred, which stops the infinite loop and return the average. 
- Stable2 currently sets the initial step size and reserves by checking the absolute difference between the target price and the high/low price from the lookup table. This results in cases where the price may be marginally closer to the target price, but in practice, the reserves are much further from the target reserves (which is most obvious in the extreme range case). This caused the newton estimation to iterate through many more times than expected. Stable2 now checks the percent difference instead, which is a much more precise check to set the guess. 