### PR TITLE
Implement tryCalcRate, implement new precision.

### DIFF
--- a/mocks/functions/MockEmptyFunction.sol
+++ b/mocks/functions/MockEmptyFunction.sol
@@ -1,7 +1,6 @@
 /**
  * SPDX-License-Identifier: MIT
  */
-
 pragma solidity ^0.8.20;
 
 import {IWellFunction} from "src/interfaces/IWellFunction.sol";
@@ -27,4 +26,6 @@ contract MockEmptyFunction is IWellFunction {
     function name() external pure override returns (string memory) {}
 
     function symbol() external pure override returns (string memory) {}
+
+    function version() external pure override returns (string memory) {}
 }

--- a/mocks/functions/MockFunctionBad.sol
+++ b/mocks/functions/MockFunctionBad.sol
@@ -1,7 +1,6 @@
 /**
  * SPDX-License-Identifier: MIT
  */
-
 pragma solidity ^0.8.20;
 
 import {IWellFunction} from "src/interfaces/IWellFunction.sol";
@@ -39,4 +38,6 @@ contract MockFunctionBad is IWellFunction {
     function name() external pure override returns (string memory) {}
 
     function symbol() external pure override returns (string memory) {}
+
+    function version() external pure override returns (string memory) {}
 }

--- a/mocks/wells/MockStaticWell.sol
+++ b/mocks/wells/MockStaticWell.sol
@@ -1,7 +1,6 @@
 /**
  * SPDX-License-Identifier: MIT
  */
-
 pragma solidity ^0.8.20;
 
 import {console} from "test/TestHelper.sol";
@@ -21,7 +20,7 @@ contract MockStaticWell is ReentrancyGuardUpgradeable, ClonePlus {
     address immutable TOKEN0;
     address immutable TOKEN1;
     address immutable WELL_FUNCTION_TARGET;
-    bytes32 immutable WELL_FUNCTION_DATA;
+    bytes internal wellFunctionData;
     address immutable PUMP0_TARGET;
     bytes32 immutable PUMP0_DATA;
     address immutable AQUIFER;
@@ -43,7 +42,7 @@ contract MockStaticWell is ReentrancyGuardUpgradeable, ClonePlus {
         TOKEN0 = address(_tokens[0]);
         TOKEN1 = address(_tokens[1]);
         WELL_FUNCTION_TARGET = _wellFunction.target;
-        WELL_FUNCTION_DATA = bytes32(_wellFunction.data);
+        wellFunctionData = _wellFunction.data;
         PUMP0_TARGET = _pumps[0].target;
         PUMP0_DATA = bytes32(_pumps[0].data);
         AQUIFER = _aquifer;
@@ -62,7 +61,7 @@ contract MockStaticWell is ReentrancyGuardUpgradeable, ClonePlus {
     }
 
     function wellFunction() public view returns (Call memory _wellFunction) {
-        _wellFunction = Call(WELL_FUNCTION_TARGET, bytes32ToBytes(WELL_FUNCTION_DATA));
+        _wellFunction = Call(WELL_FUNCTION_TARGET, wellFunctionData);
     }
 
     function pumps() public view returns (Call[] memory _pumps) {
@@ -87,7 +86,9 @@ contract MockStaticWell is ReentrancyGuardUpgradeable, ClonePlus {
     }
 
     /// @dev Inefficient way to convert bytes32 back to bytes without padding
-    function bytes32ToBytes(bytes32 data) internal pure returns (bytes memory) {
+    function bytes32ToBytes(
+        bytes32 data
+    ) internal pure returns (bytes memory) {
         uint256 i = 0;
         while (i < 32 && uint8(data[i]) != 0) {
             ++i;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@beanstalk/wells",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "A [{Well}](/src/Well.sol) is a constant function AMM that allows the provisioning of liquidity into a single pooled on-chain liquidity position.",
   "main": "index.js",
   "directories": {

--- a/src/functions/ConstantProduct.sol
+++ b/src/functions/ConstantProduct.sol
@@ -55,8 +55,14 @@ contract ConstantProduct is ProportionalLPToken, IBeanstalkWellFunction {
         return "CP";
     }
 
+    function version() external pure override returns (string memory) {
+        return "1.2.0";
+    }
+
     /// @dev calculate the mathematical product of an array of uint256[]
-    function _prodX(uint256[] memory xs) private pure returns (uint256 pX) {
+    function _prodX(
+        uint256[] memory xs
+    ) private pure returns (uint256 pX) {
         pX = xs[0];
         uint256 length = xs.length;
         for (uint256 i = 1; i < length; ++i) {
@@ -102,5 +108,20 @@ contract ConstantProduct is ProportionalLPToken, IBeanstalkWellFunction {
         bytes calldata
     ) external pure returns (uint256 rate) {
         return reserves[i] * CALC_RATE_PRECISION / reserves[j];
+    }
+
+    /**
+     * @notice Returns the precision of the ratio at which the pump will cap the reserve at.
+     * @param j The index of the reserve to solve for
+     * @param data The data passed to the well function
+     * @return precision The precision of the ratio at which the pump will cap the reserve at
+     */
+    function ratioPrecision(uint256 j, bytes calldata data) external pure returns (uint256 precision) {
+        (uint256 iDecimals, uint256 jDecimals) = abi.decode(data, (uint256, uint256));
+        if (j == 0) {
+            return ((10 ** iDecimals) * CALC_RATE_PRECISION) / (10 ** jDecimals);
+        } else {
+            return ((10 ** jDecimals) * CALC_RATE_PRECISION) / (10 ** iDecimals);
+        }
     }
 }

--- a/src/functions/ConstantProduct2.sol
+++ b/src/functions/ConstantProduct2.sol
@@ -121,16 +121,8 @@ contract ConstantProduct2 is ProportionalLPToken2, IBeanstalkWellFunction {
 
     /**
      * @notice Returns the precision of the ratio at which the pump will cap the reserve at.
-     * @param j The index of the reserve to solve for
-     * @param data The data passed to the well function
-     * @return precision The precision of the ratio at which the pump will cap the reserve at
      */
-    function ratioPrecision(uint256 j, bytes calldata data) external pure returns (uint256 precision) {
-        (uint256 iDecimals, uint256 jDecimals) = abi.decode(data, (uint256, uint256));
-        if (j == 0) {
-            return ((10 ** iDecimals) * CALC_RATE_PRECISION) / (10 ** jDecimals);
-        } else {
-            return ((10 ** jDecimals) * CALC_RATE_PRECISION) / (10 ** iDecimals);
-        }
+    function ratioPrecision(uint256, bytes calldata) external pure returns (uint256 precision) {
+        return CALC_RATE_PRECISION;
     }
 }

--- a/src/functions/ConstantProduct2.sol
+++ b/src/functions/ConstantProduct2.sol
@@ -81,6 +81,10 @@ contract ConstantProduct2 is ProportionalLPToken2, IBeanstalkWellFunction {
         return "CP2";
     }
 
+    function version() external pure override returns (string memory) {
+        return "1.2.0";
+    }
+
     /// @dev `b_j = (b_0 * b_1 * r_j / r_i)^(1/2)`
     /// Note: Always rounds down
     function calcReserveAtRatioSwap(
@@ -113,5 +117,20 @@ contract ConstantProduct2 is ProportionalLPToken2, IBeanstalkWellFunction {
         bytes calldata
     ) external pure returns (uint256 rate) {
         return reserves[i] * CALC_RATE_PRECISION / reserves[j];
+    }
+
+    /**
+     * @notice Returns the precision of the ratio at which the pump will cap the reserve at.
+     * @param j The index of the reserve to solve for
+     * @param data The data passed to the well function
+     * @return precision The precision of the ratio at which the pump will cap the reserve at
+     */
+    function ratioPrecision(uint256 j, bytes calldata data) external pure returns (uint256 precision) {
+        (uint256 iDecimals, uint256 jDecimals) = abi.decode(data, (uint256, uint256));
+        if (j == 0) {
+            return ((10 ** iDecimals) * CALC_RATE_PRECISION) / (10 ** jDecimals);
+        } else {
+            return ((10 ** jDecimals) * CALC_RATE_PRECISION) / (10 ** iDecimals);
+        }
     }
 }

--- a/src/functions/Stable2.sol
+++ b/src/functions/Stable2.sol
@@ -9,8 +9,7 @@ import {IERC20} from "forge-std/interfaces/IERC20.sol";
 
 /**
  * @author brean, deadmanwalking
- * @title Gas efficient StableSwap pricing function for Wells with 2 tokens.
- * developed by curve.
+ * @title Gas efficient Like-valued token pricing function for Wells with 2 tokens.
  *
  * Stableswap Wells with 2 tokens use the formula:
  *  `4 * A * (b_0+b_1) + D = 4 * A * D + D^3/(4 * b_0 * b_1)`

--- a/src/functions/Stable2.sol
+++ b/src/functions/Stable2.sol
@@ -58,7 +58,9 @@ contract Stable2 is ProportionalLPToken2, IBeanstalkWellFunction {
     // 2. getRatiosFromPriceSwap(uint256) -> PriceData memory
     // 3. getAParameter() -> uint256
     // Lookup tables are a function of the A parameter.
-    constructor(address lut) {
+    constructor(
+        address lut
+    ) {
         if (lut == address(0)) revert InvalidLUT();
         lookupTable = lut;
         a = ILookupTable(lut).getAParameter();
@@ -274,7 +276,6 @@ contract Stable2 is ProportionalLPToken2, IBeanstalkWellFunction {
     /**
      * @inheritdoc IBeanstalkWellFunction
      * @dev `calcReserveAtRatioLiquidity` fetches the closes approximate ratios from the target price,
-     * and performs newtons method in order to converge into a reserve.
      */
     function calcReserveAtRatioLiquidity(
         uint256[] calldata reserves,
@@ -354,7 +355,9 @@ contract Stable2 is ProportionalLPToken2, IBeanstalkWellFunction {
      * @notice decodes the data encoded in the well.
      * @return decimals an array of the decimals of the tokens in the well.
      */
-    function decodeWellData(bytes memory data) public view virtual returns (uint256[] memory decimals) {
+    function decodeWellData(
+        bytes memory data
+    ) public view virtual returns (uint256[] memory decimals) {
         (uint256 decimal0, uint256 decimal1) = abi.decode(data, (uint256, uint256));
 
         // if well data returns 0, assume 18 decimals.
@@ -379,6 +382,10 @@ contract Stable2 is ProportionalLPToken2, IBeanstalkWellFunction {
         return "S2";
     }
 
+    function version() external pure returns (string memory) {
+        return "1.1.0";
+    }
+
     /**
      * @notice internal calcRate function.
      */
@@ -395,6 +402,15 @@ contract Stable2 is ProportionalLPToken2, IBeanstalkWellFunction {
 
         // calculate rate:
         rate = _reserves[i] - calcReserve(_reserves, i, lpTokenSupply, abi.encode(18, 18));
+    }
+
+    /**
+     * @inheritdoc IMultiFlowPumpWellFunction
+     * @notice Returns the precision of the ratio at which the pump will cap the reserve at.
+     * @dev {Stable2.calcRate} returns the rate with PRICE_PRECISION, independent of data or index.
+     */
+    function ratioPrecision(uint256, bytes calldata) external pure returns (uint256 precision) {
+        return PRICE_PRECISION;
     }
 
     /**

--- a/src/interfaces/IMultiFlowPumpWellFunction.sol
+++ b/src/interfaces/IMultiFlowPumpWellFunction.sol
@@ -42,4 +42,12 @@ interface IMultiFlowPumpWellFunction is IWellFunction {
         uint256 j,
         bytes calldata data
     ) external view returns (uint256 rate);
+
+    /**
+     * @notice Returns the precision of the ratio at which the pump will cap the reserve at.
+     * @param j The index of the reserve to solve for
+     * @param data The data passed to the well function
+     * @return precision The precision of the ratio at which the pump will cap the reserve at
+     */
+    function ratioPrecision(uint256 j, bytes calldata data) external view returns (uint256);
 }

--- a/src/interfaces/IWellFunction.sol
+++ b/src/interfaces/IWellFunction.sol
@@ -70,4 +70,9 @@ interface IWellFunction {
      * @notice Returns the symbol of the Well function.
      */
     function symbol() external view returns (string memory);
+
+    /**
+     * @notice Returns the version of the Well function.
+     */
+    function version() external view returns (string memory);
 }

--- a/test/pumps/Pump.CapReserves.t.sol
+++ b/test/pumps/Pump.CapReserves.t.sol
@@ -51,7 +51,7 @@ contract CapBalanceTest is TestHelper, MultiFlowPump {
 
         _well = address(
             new MockStaticWell(
-                deployMockTokens(2), Call(address(wf), new bytes(0)), deployPumps(1), address(0), new bytes(0)
+                deployMockTokens(2), Call(address(wf), abi.encode(18, 18)), deployPumps(1), address(0), new bytes(0)
             )
         );
     }

--- a/test/pumps/Pump.Fuzz.t.sol
+++ b/test/pumps/Pump.Fuzz.t.sol
@@ -34,6 +34,7 @@ contract PumpFuzzTest is TestHelper, MultiFlowPump {
         pump = new MultiFlowPump();
         data = mockPumpData();
         wellFunction.target = address(new ConstantProduct2());
+        wellFunction.data = abi.encode(18, 18);
         mWell.setWellFunction(wellFunction);
     }
 

--- a/test/pumps/Pump.Update.t.sol
+++ b/test/pumps/Pump.Update.t.sol
@@ -28,6 +28,7 @@ contract PumpUpdateTest is TestHelper {
         pump = new MultiFlowPump();
         data = mockPumpData();
         wellFunction.target = address(new ConstantProduct2());
+        wellFunction.data = abi.encode(18, 18);
         mWell.setWellFunction(wellFunction);
 
         // Send first update to the Pump, which will initialize it


### PR DESCRIPTION
## Problem 

When MultiFlowPump attempts to Cap the change in ratio of `reserves`, It calls `WellFunction.calcRate(..)` in order to calculate the last rate with the last reserves, and the current rate. If `calcRate` fails, then the Pump reverts, and thus bricks the Well. 

When MultiFlowPump attempts to calculate the Capped Reserves, it assumes the Well uses a Constant Product 2 Well Function.
## Solution

- Update MultiFlowPump to fail gracefully when `calcRate` fails.
 
- Update `IMultiFlowWellFunction` to implement `ratioPrecision(uint256 j, bytes data)`, which returns the precision that the MultiFlowPump should use when calculating the capped Reserves. 

- Update `MultiFlowPump` to use `ratioPrecision` when calculating for `ratios[j]` in `calcReservesAtRatioSwap`. 

- Update `ConstantProduct2`, `ConstantProduct`, and `Stable2` to implement `ratioPrecision`. 

- Update `IWellFunction` to implement `version()`, allowing users to verify WellFunctions. 

